### PR TITLE
add log recover tool

### DIFF
--- a/unmaintained/download_logs/download_logs.go
+++ b/unmaintained/download_logs/download_logs.go
@@ -12,8 +12,6 @@ import (
 	"strings"
 	"sync"
 	"time"
-
-	util_http "github.com/seaweedfs/seaweedfs/weed/util/http"
 )
 
 var (
@@ -61,7 +59,6 @@ type DownloadStats struct {
 
 func main() {
 	flag.Parse()
-	util_http.InitGlobalHttpClient()
 
 	if *filerURL == "" {
 		fmt.Fprintf(os.Stderr, "Error: filer URL is required\n")
@@ -188,10 +185,7 @@ func walkDirectory(client *http.Client, filerURL, remotePath, localBasePath stri
 	fmt.Printf("Found %d entries, in %s\n", len(entries), filerURL)
 
 	for _, entry := range entries {
-		fmt.Printf("entry name: %s, file size: %d, mod time: %s\n", entry.FullPath, entry.FileSize, entry.ModTime)
 
-		// filer REST API does not return if an entry is a directory, here assume
-		// if the file size is 0, and name like yyyy-mm-dd, it is a log directory
 		baseName := filepath.Base(entry.FullPath)
 
 		if os.FileMode(entry.Mode).IsDir() {
@@ -223,7 +217,7 @@ func walkDirectory(client *http.Client, filerURL, remotePath, localBasePath stri
 			*tasks = append(*tasks, task)
 
 			if *verbose {
-				fmt.Printf("  File: %s (%d bytes)\n", entry.FullPath, entry.FileSize)
+				fmt.Printf("entry name: %s, file size: %d, mod time: %s\n", entry.FullPath, entry.FileSize, entry.ModTime)
 			}
 		}
 	}

--- a/unmaintained/download_logs/download_logs.go
+++ b/unmaintained/download_logs/download_logs.go
@@ -1,0 +1,458 @@
+package main
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+
+	util_http "github.com/seaweedfs/seaweedfs/weed/util/http"
+)
+
+var (
+	filerURL    = flag.String("filer", "", "filer URL (e.g., http://192.168.2.11:8888)")
+	logPath     = flag.String("path", "/topics/.system/log", "log path on filer (default: /topics/.system/log)")
+	outputDir   = flag.String("output", "downloaded_logs", "local output directory")
+	concurrency = flag.Int("concurrency", 4, "number of concurrent downloads")
+	verbose     = flag.Bool("v", false, "verbose output")
+	retryCount  = flag.Int("retry", 3, "number of retries for failed downloads")
+	timeout     = flag.Int("timeout", 30, "timeout in seconds for each download")
+)
+
+// FilerEntry represents a file or directory entry from filer API
+type FilerEntry struct {
+	FullPath string `json:"FullPath"`
+	Mode     uint32 `json:"Mode"`
+	FileSize int64  `json:"FileSize"`
+	ModTime  string `json:"Mtime"`
+}
+
+// FilerListResponse represents the response from filer list API
+type FilerListResponse struct {
+	Path    string       `json:"Path"`
+	Entries []FilerEntry `json:"Entries"`
+}
+
+// DownloadTask represents a single file download task
+type DownloadTask struct {
+	RemotePath string
+	LocalPath  string
+	Size       int64
+	ModTime    string
+}
+
+// DownloadStats tracks download statistics
+type DownloadStats struct {
+	TotalFiles     int
+	TotalSize      int64
+	DownloadedSize int64
+	CompletedFiles int
+	FailedFiles    int
+	StartTime      time.Time
+	mu             sync.Mutex
+}
+
+func main() {
+	flag.Parse()
+	util_http.InitGlobalHttpClient()
+
+	if *filerURL == "" {
+		fmt.Fprintf(os.Stderr, "Error: filer URL is required\n")
+		flag.Usage()
+		os.Exit(1)
+	}
+
+	// Validate and normalize filer URL
+	if !strings.HasPrefix(*filerURL, "http://") && !strings.HasPrefix(*filerURL, "https://") {
+		*filerURL = "http://" + *filerURL
+	}
+	*filerURL = strings.TrimSuffix(*filerURL, "/")
+
+	fmt.Printf("SeaweedFS Log Downloader\n")
+	fmt.Printf("Filer URL: %s\n", *filerURL)
+	fmt.Printf("Log path: %s\n", *logPath)
+	fmt.Printf("Output directory: %s\n", *outputDir)
+
+	// Discover all log files
+	if *verbose {
+		fmt.Printf("\n=== Discovering log files ===\n")
+	}
+
+	downloadTasks, err := discoverLogFiles(*filerURL, *logPath)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error discovering log files: %v\n", err)
+		os.Exit(1)
+	}
+
+	if len(downloadTasks) == 0 {
+		fmt.Printf("No log files found in %s\n", *logPath)
+		return
+	}
+
+	// Calculate total size
+	var totalSize int64
+	for _, task := range downloadTasks {
+		totalSize += task.Size
+	}
+
+	fmt.Printf("\n=== Download Summary ===\n")
+	fmt.Printf("Found %d log files\n", len(downloadTasks))
+	fmt.Printf("Total size: %.2f MB\n", float64(totalSize)/(1024*1024))
+
+	// Create output directory
+	if err := os.MkdirAll(*outputDir, 0755); err != nil {
+		fmt.Fprintf(os.Stderr, "Error creating output directory: %v\n", err)
+		os.Exit(1)
+	}
+
+	// Download files
+	stats := &DownloadStats{
+		TotalFiles: len(downloadTasks),
+		TotalSize:  totalSize,
+		StartTime:  time.Now(),
+	}
+
+	fmt.Printf("\n=== Starting Downloads ===\n")
+	err = downloadFiles(downloadTasks, stats)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error during download: %v\n", err)
+		os.Exit(1)
+	}
+
+	// Print final statistics
+	elapsed := time.Since(stats.StartTime)
+	fmt.Printf("\n=== Download Complete ===\n")
+	fmt.Printf("Successfully downloaded: %d/%d files\n", stats.CompletedFiles, stats.TotalFiles)
+	fmt.Printf("Failed downloads: %d\n", stats.FailedFiles)
+	fmt.Printf("Total size downloaded: %.2f MB\n", float64(stats.DownloadedSize)/(1024*1024))
+	fmt.Printf("Total time: %v\n", elapsed)
+	if elapsed.Seconds() > 0 {
+		fmt.Printf("Average speed: %.2f MB/s\n",
+			float64(stats.DownloadedSize)/(1024*1024)/elapsed.Seconds())
+	}
+
+	if stats.FailedFiles == 0 {
+		fmt.Printf("\n✅ All files downloaded successfully!\n")
+		fmt.Printf("You can now run: ./log_recover_all -logdir=%s\n", *outputDir)
+	} else {
+		fmt.Printf("\n⚠️  Some downloads failed. Check the output for details.\n")
+	}
+}
+
+// discoverLogFiles recursively discovers all log files in the given path
+func discoverLogFiles(filerURL, logPath string) ([]*DownloadTask, error) {
+	var allTasks []*DownloadTask
+	visited := make(map[string]bool)
+
+	err := walkDirectory(filerURL, logPath, *outputDir, &allTasks, visited)
+	if err != nil {
+		return nil, err
+	}
+
+	// Sort by remote path for consistent ordering
+	sort.Slice(allTasks, func(i, j int) bool {
+		return allTasks[i].RemotePath < allTasks[j].RemotePath
+	})
+
+	return allTasks, nil
+}
+
+// walkDirectory recursively walks a directory and collects download tasks
+func walkDirectory(filerURL, remotePath, localBasePath string, tasks *[]*DownloadTask, visited map[string]bool) error {
+	// Prevent infinite loops
+	if visited[remotePath] {
+		return nil
+	}
+	visited[remotePath] = true
+
+	if *verbose {
+		fmt.Printf("Scanning: %s\n", remotePath)
+	}
+
+	entries, err := listDirectory(filerURL, remotePath)
+	if err != nil {
+		return fmt.Errorf("failed to list directory %s: %v", remotePath, err)
+	}
+	fmt.Printf("Found %d entries, in %s\n", len(entries), filerURL)
+
+	for _, entry := range entries {
+		fmt.Printf("entry name: %s, file size: %d, mod time: %s\n", entry.FullPath, entry.FileSize, entry.ModTime)
+
+		// filer REST API does not return if an entry is a directory, here assume
+		// if the file size is 0, and name like yyyy-mm-dd, it is a log directory
+		baseName := filepath.Base(entry.FullPath)
+
+		if entry.FileSize == 0 && isValidDateStr(baseName) {
+			// scan log files inside
+			subRemotePath := filepath.Join(remotePath, baseName)
+			err := walkDirectory(filerURL, subRemotePath, localBasePath, tasks, visited)
+			if err != nil {
+				if *verbose {
+					fmt.Printf("Warning: failed to scan directory %s: %v\n", subRemotePath, err)
+				}
+				continue
+			}
+		} else {
+			// Add file to download tasks
+			remoteFilePath := filepath.Join(remotePath, filepath.Base(entry.FullPath))
+
+			// Calculate local path - remove the log path prefix and add to output dir
+			relPath := strings.TrimPrefix(remoteFilePath, *logPath)
+			relPath = strings.TrimPrefix(relPath, "/")
+			localFilePath := filepath.Join(localBasePath, relPath)
+
+			task := &DownloadTask{
+				RemotePath: remoteFilePath,
+				LocalPath:  localFilePath,
+				Size:       entry.FileSize,
+				ModTime:    entry.ModTime,
+			}
+
+			*tasks = append(*tasks, task)
+
+			if *verbose {
+				fmt.Printf("  File: %s (%d bytes)\n", entry.FullPath, entry.FileSize)
+			}
+		}
+	}
+
+	return nil
+}
+
+func listDirectory(filerURL, path string) ([]FilerEntry, error) {
+	apiURL := fmt.Sprintf("%s%s?pretty=y", filerURL, path)
+
+	if *verbose {
+		fmt.Printf("GET %s\n", apiURL)
+	}
+
+	// Create HTTP request with proper headers
+	req, err := http.NewRequest("GET", apiURL, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %v", err)
+	}
+
+	// Set Accept header for JSON response
+	req.Header.Set("Accept", "application/json")
+
+	// Make HTTP request
+	client := &http.Client{
+		Timeout: time.Duration(*timeout) * time.Second,
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("HTTP request failed: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		bodyBytes, _ := io.ReadAll(resp.Body)
+		return nil, fmt.Errorf("HTTP %d: %s", resp.StatusCode, string(bodyBytes))
+	}
+
+	// Parse JSON response
+	var listResp FilerListResponse
+	decoder := json.NewDecoder(resp.Body)
+	err = decoder.Decode(&listResp)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse JSON response: %v", err)
+	}
+
+	return listResp.Entries, nil
+}
+
+// downloadFiles downloads all files with concurrent workers
+func downloadFiles(tasks []*DownloadTask, stats *DownloadStats) error {
+	taskChan := make(chan *DownloadTask, len(tasks))
+	var wg sync.WaitGroup
+
+	// Start progress reporter
+	stopProgress := make(chan bool)
+	go func() {
+		ticker := time.NewTicker(2 * time.Second)
+		defer ticker.Stop()
+
+		for {
+			select {
+			case <-ticker.C:
+				stats.mu.Lock()
+				if stats.TotalSize > 0 {
+					percent := float64(stats.DownloadedSize) * 100 / float64(stats.TotalSize)
+					fmt.Printf("\rProgress: %.1f%% (%d/%d files, %.2f MB/%.2f MB)",
+						percent, stats.CompletedFiles, stats.TotalFiles,
+						float64(stats.DownloadedSize)/(1024*1024),
+						float64(stats.TotalSize)/(1024*1024))
+				}
+				stats.mu.Unlock()
+			case <-stopProgress:
+				return
+			}
+		}
+	}()
+
+	// Start worker goroutines
+	for i := 0; i < *concurrency; i++ {
+		wg.Add(1)
+		go func(workerID int) {
+			defer wg.Done()
+			for task := range taskChan {
+				err := downloadFile(task, stats, workerID)
+				if err != nil {
+					fmt.Printf("\nWorker %d: Failed to download %s: %v\n",
+						workerID, task.RemotePath, err)
+					stats.mu.Lock()
+					stats.FailedFiles++
+					stats.mu.Unlock()
+				}
+			}
+		}(i)
+	}
+
+	// Send tasks to workers
+	for _, task := range tasks {
+		taskChan <- task
+	}
+	close(taskChan)
+
+	// Wait for completion
+	wg.Wait()
+	stopProgress <- true
+
+	fmt.Printf("\n") // New line after progress
+
+	return nil
+}
+
+// downloadFile downloads a single file with retries
+func downloadFile(task *DownloadTask, stats *DownloadStats, workerID int) error {
+	var lastErr error
+
+	for attempt := 1; attempt <= *retryCount; attempt++ {
+		err := downloadFileAttempt(task, stats, workerID)
+		if err == nil {
+			return nil
+		}
+
+		lastErr = err
+		if attempt < *retryCount {
+			if *verbose {
+				fmt.Printf("Worker %d: Retry %d/%d for %s: %v\n",
+					workerID, attempt, *retryCount, task.RemotePath, err)
+			}
+			time.Sleep(time.Duration(attempt) * time.Second) // Exponential backoff
+		}
+	}
+
+	return lastErr
+}
+
+// downloadFileAttempt performs a single download attempt
+func downloadFileAttempt(task *DownloadTask, stats *DownloadStats, workerID int) error {
+	// Create local directory if needed
+	localDir := filepath.Dir(task.LocalPath)
+	if err := os.MkdirAll(localDir, 0755); err != nil {
+		return fmt.Errorf("failed to create directory %s: %v", localDir, err)
+	}
+
+	// Check if file already exists and has the same size
+	if info, err := os.Stat(task.LocalPath); err == nil {
+		if info.Size() == task.Size {
+			if *verbose {
+				fmt.Printf("Worker %d: Skipping %s (already exists)\n",
+					workerID, task.RemotePath)
+			}
+			stats.mu.Lock()
+			stats.CompletedFiles++
+			stats.DownloadedSize += task.Size
+			stats.mu.Unlock()
+			return nil
+		}
+	}
+
+	// Construct download URL
+	downloadURL := fmt.Sprintf("%s%s", *filerURL, task.RemotePath)
+
+	if *verbose {
+		fmt.Printf("Worker %d: Downloading %s\n", workerID, task.RemotePath)
+	}
+
+	// Create HTTP request
+	req, err := http.NewRequest("GET", downloadURL, nil)
+	if err != nil {
+		return fmt.Errorf("failed to create request: %v", err)
+	}
+
+	// Make HTTP request
+	client := &http.Client{
+		Timeout: time.Duration(*timeout) * time.Second,
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return fmt.Errorf("HTTP request failed: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("HTTP %d", resp.StatusCode)
+	}
+
+	// Create temporary file
+	tmpPath := task.LocalPath + ".tmp"
+	tmpFile, err := os.Create(tmpPath)
+	if err != nil {
+		return fmt.Errorf("failed to create temp file: %v", err)
+	}
+
+	// Copy data
+	written, err := io.Copy(tmpFile, resp.Body)
+	tmpFile.Close()
+
+	if err != nil {
+		os.Remove(tmpPath)
+		return fmt.Errorf("failed to copy data: %v", err)
+	}
+
+	// Verify size
+	if written != task.Size {
+		os.Remove(tmpPath)
+		return fmt.Errorf("size mismatch: got %d, expected %d", written, task.Size)
+	}
+
+	// Rename to final path
+	if err := os.Rename(tmpPath, task.LocalPath); err != nil {
+		os.Remove(tmpPath)
+		return fmt.Errorf("failed to rename file: %v", err)
+	}
+
+	// Set modification time
+	if task.ModTime != "" {
+		// convert task.ModTime from string to time.Time
+		modTime, err := time.Parse(time.RFC3339, task.ModTime)
+		if err != nil {
+			return fmt.Errorf("failed to parse modTime: %v", err)
+		}
+		os.Chtimes(task.LocalPath, modTime, modTime)
+	}
+
+	// Update statistics
+	stats.mu.Lock()
+	stats.CompletedFiles++
+	stats.DownloadedSize += written
+	stats.mu.Unlock()
+
+	return nil
+}
+
+func isValidDateStr(s string) bool {
+	_, err := time.Parse("2006-01-02", s)
+	return err == nil
+}

--- a/unmaintained/find_deleted_files/find_deleted_files.go
+++ b/unmaintained/find_deleted_files/find_deleted_files.go
@@ -1,0 +1,542 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"io"
+	"log"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+	"time"
+
+	"google.golang.org/protobuf/proto"
+
+	"github.com/seaweedfs/seaweedfs/weed/pb/filer_pb"
+	"github.com/seaweedfs/seaweedfs/weed/util"
+	util_http "github.com/seaweedfs/seaweedfs/weed/util/http"
+)
+
+var (
+	logDir         = flag.String("logdir", "", "directory containing log files (e.g., downloaded_logs)")
+	logFile        = flag.String("logfile", "", "single log file to analyze")
+	outputFile     = flag.String("output", "", "output file (default: stdout)")
+	verbose        = flag.Bool("v", false, "verbose output")
+	showDetails    = flag.Bool("details", false, "show detailed file information (chunks, attributes)")
+	pathFilter     = flag.String("path", "", "filter by path prefix (e.g., /bucket/subfolder/)")
+	timeFrom       = flag.String("time-from", "", "filter by time from (RFC3339 format, e.g., 2025-09-03T00:00:00Z)")
+	timeTo         = flag.String("time-to", "", "filter by time to (RFC3339 format, e.g., 2025-09-03T23:59:59Z)")
+	includeUploads = flag.Bool("include-uploads", false, "include .uploads directory deletions (internal multipart operations)")
+	batchSize      = flag.Int("batch-size", 1000, "number of files to track in memory at once")
+	maxMemoryMB    = flag.Int("max-memory", 500, "maximum memory usage in MB (approximate)")
+)
+
+// FileLifecycleSummary represents a lightweight file lifecycle summary
+type FileLifecycleSummary struct {
+	Path            string
+	Name            string
+	Directory       string
+	FirstCreateTime *time.Time
+	LastDeleteTime  *time.Time
+	LastEventType   string // "create", "update", "delete"
+	LastEventTime   time.Time
+	CreateTimestamp int64 // from attributes
+	FileSize        uint64
+	IsDirectory     bool
+	EventCount      int
+}
+
+// MemoryTracker tracks memory usage
+type MemoryTracker struct {
+	TrackedFiles int
+	MaxFiles     int
+}
+
+// DeletedFileRecord represents a permanently deleted file record
+type DeletedFileRecord struct {
+	Path        string
+	Name        string
+	Directory   string
+	DeleteTime  time.Time  // When the file was deleted
+	CreateTime  *time.Time // When the file was created (may be nil)
+	Entry       *filer_pb.Entry
+}
+
+// Regex pattern for log files: XX-XX.XXXXXXXX (time.8-char-hex)
+var logFilePattern = regexp.MustCompile(`^\d{2}-\d{2}\.[a-f0-9]{8}$`)
+
+func main() {
+	flag.Usage = func() {
+		fmt.Fprintf(os.Stderr, "Usage: %s [OPTIONS]\n\n", os.Args[0])
+		fmt.Fprintf(os.Stderr, "Find deleted files from SeaweedFS filer log files.\n\n")
+		fmt.Fprintf(os.Stderr, "Examples:\n")
+		fmt.Fprintf(os.Stderr, "  # Analyze all log files in directory\n")
+		fmt.Fprintf(os.Stderr, "  %s -logdir=downloaded_logs\n\n", os.Args[0])
+		fmt.Fprintf(os.Stderr, "  # Analyze single log file\n")
+		fmt.Fprintf(os.Stderr, "  %s -logfile=downloaded_logs/2025-09-03/09-32.6e72fd9a\n\n", os.Args[0])
+		fmt.Fprintf(os.Stderr, "  # Filter by path and show details\n")
+		fmt.Fprintf(os.Stderr, "  %s -logdir=downloaded_logs -path=/bucket/docs/ -details\n\n", os.Args[0])
+		fmt.Fprintf(os.Stderr, "  # Filter by time range\n")
+		fmt.Fprintf(os.Stderr, "  %s -logdir=downloaded_logs -time-from=2025-09-03T10:00:00Z -time-to=2025-09-03T12:00:00Z\n\n", os.Args[0])
+		fmt.Fprintf(os.Stderr, "  # Include .uploads directory deletions (normally filtered out)\n")
+		fmt.Fprintf(os.Stderr, "  %s -logdir=downloaded_logs -include-uploads\n\n", os.Args[0])
+		fmt.Fprintf(os.Stderr, "  # Control memory usage for large datasets\n")
+		fmt.Fprintf(os.Stderr, "  %s -logdir=downloaded_logs -batch-size=500 -max-memory=200\n\n", os.Args[0])
+		fmt.Fprintf(os.Stderr, "Options:\n")
+		flag.PrintDefaults()
+	}
+
+	flag.Parse()
+	util_http.InitGlobalHttpClient()
+
+	if *logDir == "" && *logFile == "" {
+		fmt.Fprintf(os.Stderr, "Error: either -logdir or -logfile must be specified\n")
+		flag.Usage()
+		os.Exit(1)
+	}
+
+	if *logDir != "" && *logFile != "" {
+		fmt.Fprintf(os.Stderr, "Error: cannot use both -logdir and -logfile at the same time\n")
+		os.Exit(1)
+	}
+
+	// Parse time filters
+	var fromTime, toTime *time.Time
+	if *timeFrom != "" {
+		t, err := time.Parse(time.RFC3339, *timeFrom)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error: invalid time-from format. Use RFC3339 format (e.g., 2025-09-03T10:00:00Z)\n")
+			os.Exit(1)
+		}
+		fromTime = &t
+	}
+
+	if *timeTo != "" {
+		t, err := time.Parse(time.RFC3339, *timeTo)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error: invalid time-to format. Use RFC3339 format (e.g., 2025-09-03T23:59:59Z)\n")
+			os.Exit(1)
+		}
+		toTime = &t
+	}
+
+	fmt.Printf("SeaweedFS Deleted Files Finder\n")
+
+	var deletedFiles []DeletedFileRecord
+	var err error
+
+	if *logFile != "" {
+		fmt.Printf("Analyzing single log file: %s\n", *logFile)
+		deletedFiles, err = analyzeLogFile(*logFile, fromTime, toTime)
+		if err != nil {
+			log.Fatalf("failed to analyze log file %s: %v", *logFile, err)
+		}
+	} else {
+		fmt.Printf("Analyzing log directory: %s\n", *logDir)
+		deletedFiles, err = analyzeLogDirectory(*logDir, fromTime, toTime)
+		if err != nil {
+			log.Fatalf("failed to analyze log directory %s: %v", *logDir, err)
+		}
+	}
+
+	// Apply path filter
+	if *pathFilter != "" {
+		filtered := make([]DeletedFileRecord, 0)
+		for _, record := range deletedFiles {
+			fullPath := filepath.Join(record.Directory, record.Name)
+			if strings.HasPrefix(fullPath, *pathFilter) {
+				filtered = append(filtered, record)
+			}
+		}
+		deletedFiles = filtered
+		fmt.Printf("Path filter: %s\n", *pathFilter)
+	}
+
+	// Sort by delete timestamp
+	sort.Slice(deletedFiles, func(i, j int) bool {
+		return deletedFiles[i].DeleteTime.Before(deletedFiles[j].DeleteTime)
+	})
+
+	fmt.Printf("\n=== Found %d deleted files ===\n", len(deletedFiles))
+
+	// Setup output writer
+	var writer *os.File
+	if *outputFile != "" {
+		writer, err = os.Create(*outputFile)
+		if err != nil {
+			log.Fatalf("failed to create output file: %v", err)
+		}
+		defer writer.Close()
+		fmt.Printf("Writing results to: %s\n\n", *outputFile)
+	} else {
+		writer = os.Stdout
+	}
+
+	// Output results
+	outputResults(writer, deletedFiles)
+
+	if len(deletedFiles) > 0 {
+		fmt.Printf("\n✅ Analysis complete. Found %d deleted files.\n", len(deletedFiles))
+	} else {
+		fmt.Printf("\n📝 No deleted files found matching the criteria.\n")
+	}
+}
+
+func isLogFile(filename string) bool {
+	return logFilePattern.MatchString(filename)
+}
+
+// isUploadPath checks if a path is related to .uploads directory (multipart upload operations)
+// Matches paths like: /buckets/bucket1/.uploads, /buckets/bucket1/.uploads/xxx, etc.
+func isUploadPath(path string) bool {
+	return strings.Contains(path, "/.uploads/") || strings.HasSuffix(path, "/.uploads")
+}
+
+func analyzeLogDirectory(logDir string, fromTime, toTime *time.Time) ([]DeletedFileRecord, error) {
+	// Calculate memory limits
+	estimatedBytesPerFile := 200 // rough estimate per file lifecycle
+	maxFiles := (*maxMemoryMB * 1024 * 1024) / estimatedBytesPerFile
+	if maxFiles < *batchSize {
+		maxFiles = *batchSize
+	}
+
+	if *verbose {
+		fmt.Printf("Memory limit: %d MB, max tracked files: %d\n", *maxMemoryMB, maxFiles)
+	}
+
+	// Collect log files first
+	var logFiles []string
+	err := filepath.Walk(logDir, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+
+		if info.IsDir() {
+			return nil
+		}
+
+		// Check if file matches log file pattern (XX-XX.XXXXXXXX)
+		if !isLogFile(info.Name()) {
+			if *verbose {
+				fmt.Printf("Skipping non-log file: %s\n", info.Name())
+			}
+			return nil
+		}
+
+		logFiles = append(logFiles, path)
+		return nil
+	})
+
+	if err != nil {
+		return nil, err
+	}
+
+	if *verbose {
+		fmt.Printf("Found %d log files to process\n", len(logFiles))
+	}
+
+	// Process log files in streaming fashion
+	return processLogFilesStreaming(logFiles, maxFiles, fromTime, toTime)
+}
+
+func analyzeLogFile(filePath string, fromTime, toTime *time.Time) ([]DeletedFileRecord, error) {
+	// For single file analysis, use simplified processing
+	maxFiles := (*maxMemoryMB * 1024 * 1024) / 200 // estimate 200 bytes per file
+	if maxFiles < *batchSize {
+		maxFiles = *batchSize
+	}
+	
+	return processLogFilesStreaming([]string{filePath}, maxFiles, fromTime, toTime)
+}
+
+// processLogFilesStreaming processes log files in a memory-efficient streaming manner
+func processLogFilesStreaming(logFiles []string, maxFiles int, fromTime, toTime *time.Time) ([]DeletedFileRecord, error) {
+	var allDeletedFiles []DeletedFileRecord
+	fileLifecycles := make(map[string]*FileLifecycleSummary)
+	memTracker := &MemoryTracker{MaxFiles: maxFiles}
+
+	for _, logFile := range logFiles {
+		if *verbose {
+			fmt.Printf("Processing: %s\n", logFile)
+		}
+
+		err := processLogFileEventsStreaming(logFile, fileLifecycles, memTracker)
+		if err != nil {
+			if *verbose {
+				fmt.Printf("Warning: failed to analyze %s: %v\n", logFile, err)
+			}
+			continue
+		}
+
+		// Check if we need to flush some results to manage memory
+		if memTracker.TrackedFiles > maxFiles {
+			if *verbose {
+				fmt.Printf("Memory limit reached (%d files), flushing batch...\n", memTracker.TrackedFiles)
+			}
+			
+			batch := findPermanentlyDeletedFilesStreaming(fileLifecycles, fromTime, toTime)
+			allDeletedFiles = append(allDeletedFiles, batch...)
+			
+			// Clear processed lifecycles to free memory
+			fileLifecycles = make(map[string]*FileLifecycleSummary)
+			memTracker.TrackedFiles = 0
+		}
+	}
+
+	// Process final batch
+	if len(fileLifecycles) > 0 {
+		batch := findPermanentlyDeletedFilesStreaming(fileLifecycles, fromTime, toTime)
+		allDeletedFiles = append(allDeletedFiles, batch...)
+	}
+
+	return allDeletedFiles, nil
+}
+
+// processLogFileEventsStreaming processes all events from a single log file with memory efficiency
+func processLogFileEventsStreaming(filePath string, fileLifecycles map[string]*FileLifecycleSummary, memTracker *MemoryTracker) error {
+	file, err := os.OpenFile(filePath, os.O_RDONLY, 0644)
+	if err != nil {
+		return err
+	}
+	defer file.Close()
+
+	sizeBuf := make([]byte, 4)
+
+	for {
+		if n, err := file.Read(sizeBuf); n != 4 {
+			if err == io.EOF {
+				break
+			}
+			return err
+		}
+
+		size := util.BytesToUint32(sizeBuf)
+		data := make([]byte, int(size))
+
+		if n, err := file.Read(data); n != len(data) {
+			return err
+		}
+
+		logEntry := &filer_pb.LogEntry{}
+		err := proto.Unmarshal(data, logEntry)
+		if err != nil {
+			if *verbose {
+				log.Printf("Warning: unexpected unmarshal filer_pb.LogEntry: %v", err)
+			}
+			continue
+		}
+
+		event := &filer_pb.SubscribeMetadataResponse{}
+		err = proto.Unmarshal(logEntry.Data, event)
+		if err != nil {
+			if *verbose {
+				log.Printf("Warning: unexpected unmarshal filer_pb.SubscribeMetadataResponse: %v", err)
+			}
+			continue
+		}
+
+		timestamp := time.Unix(0, int64(logEntry.TsNs))
+		
+		// Process different event types
+		var eventType string
+		var entry *filer_pb.Entry
+		var fullPath string
+
+		switch {
+		case event.EventNotification.NewEntry != nil && event.EventNotification.OldEntry == nil:
+			// File create
+			eventType = "create"
+			entry = event.EventNotification.NewEntry
+			fullPath = filepath.Join(event.Directory, entry.Name)
+			
+		case event.EventNotification.NewEntry != nil && event.EventNotification.OldEntry != nil:
+			// File update
+			eventType = "update"
+			entry = event.EventNotification.NewEntry
+			fullPath = filepath.Join(event.Directory, entry.Name)
+			
+		case event.EventNotification.NewEntry == nil && event.EventNotification.OldEntry != nil:
+			// File delete
+			eventType = "delete"
+			entry = event.EventNotification.OldEntry
+			fullPath = filepath.Join(event.Directory, entry.Name)
+			
+		default:
+			// Unknown event, skip
+			continue
+		}
+
+		// Get or create file lifecycle summary
+		if fileLifecycles[fullPath] == nil {
+			fileLifecycles[fullPath] = &FileLifecycleSummary{
+				Path:      fullPath,
+				Name:      entry.Name,
+				Directory: event.Directory,
+			}
+			memTracker.TrackedFiles++
+		}
+
+		lifecycle := fileLifecycles[fullPath]
+		lifecycle.EventCount++
+		
+		// Update lifecycle state (only keep essential info)
+		if eventType == "create" && lifecycle.FirstCreateTime == nil {
+			lifecycle.FirstCreateTime = &timestamp
+		}
+		if eventType == "delete" {
+			lifecycle.LastDeleteTime = &timestamp
+		}
+		
+		// Always update last event info
+		lifecycle.LastEventType = eventType
+		lifecycle.LastEventTime = timestamp
+		
+		// Extract essential info from entry (avoid storing full entry)
+		if entry.Attributes != nil {
+			if entry.Attributes.Crtime > 0 {
+				lifecycle.CreateTimestamp = entry.Attributes.Crtime
+			}
+			lifecycle.FileSize = entry.Attributes.FileSize
+		}
+		lifecycle.IsDirectory = entry.IsDirectory
+	}
+
+	return nil
+}
+
+// findPermanentlyDeletedFilesStreaming analyzes lightweight file lifecycles to find truly deleted files
+func findPermanentlyDeletedFilesStreaming(fileLifecycles map[string]*FileLifecycleSummary, fromTime, toTime *time.Time) []DeletedFileRecord {
+	var records []DeletedFileRecord
+
+	for fullPath, lifecycle := range fileLifecycles {
+		// Only include files that are finally deleted
+		if lifecycle.LastEventType != "delete" {
+			continue
+		}
+
+		// Apply time filters to delete time
+		if lifecycle.LastDeleteTime == nil {
+			continue
+		}
+		
+		if fromTime != nil && lifecycle.LastDeleteTime.Before(*fromTime) {
+			continue
+		}
+		if toTime != nil && lifecycle.LastDeleteTime.After(*toTime) {
+			continue
+		}
+
+		// Filter out .uploads directory deletions unless explicitly requested
+		if !*includeUploads && isUploadPath(fullPath) {
+			if *verbose {
+				fmt.Printf("Skipping .uploads path: %s\n", fullPath)
+			}
+			continue
+		}
+
+		// Extract creation time
+		var createTime *time.Time
+		if lifecycle.CreateTimestamp > 0 {
+			ct := time.Unix(lifecycle.CreateTimestamp, 0)
+			createTime = &ct
+		} else if lifecycle.FirstCreateTime != nil {
+			createTime = lifecycle.FirstCreateTime
+		}
+
+		// Create a minimal entry for compatibility
+		entry := &filer_pb.Entry{
+			Name:        lifecycle.Name,
+			IsDirectory: lifecycle.IsDirectory,
+		}
+		if lifecycle.FileSize > 0 || lifecycle.CreateTimestamp > 0 {
+			entry.Attributes = &filer_pb.FuseAttributes{
+				FileSize: lifecycle.FileSize,
+				Crtime:   lifecycle.CreateTimestamp,
+			}
+		}
+
+		record := DeletedFileRecord{
+			Path:       fullPath,
+			Name:       lifecycle.Name,
+			Directory:  lifecycle.Directory,
+			DeleteTime: *lifecycle.LastDeleteTime,
+			CreateTime: createTime,
+			Entry:      entry,
+		}
+
+		records = append(records, record)
+	}
+
+	return records
+}
+
+func outputResults(writer *os.File, records []DeletedFileRecord) {
+	if len(records) == 0 {
+		return
+	}
+
+	// Output header
+	if *showDetails {
+		fmt.Fprintf(writer, "%-30s %-30s %-50s %-8s %-12s %s\n", "DELETE_TIME", "CREATE_TIME", "PATH", "IS_DIR", "SIZE", "DETAILS")
+		fmt.Fprintf(writer, "%s\n", strings.Repeat("-", 150))
+	} else {
+		fmt.Fprintf(writer, "%-30s %-30s %s\n", "DELETE_TIME", "CREATE_TIME", "PATH")
+		fmt.Fprintf(writer, "%s\n", strings.Repeat("-", 110))
+	}
+
+	for _, record := range records {
+		deleteTimeStr := record.DeleteTime.Format(time.RFC3339)
+		
+		var createTimeStr string
+		if record.CreateTime != nil {
+			createTimeStr = record.CreateTime.Format(time.RFC3339)
+		} else {
+			createTimeStr = "N/A"
+		}
+
+		if *showDetails {
+			isDir := "false"
+			if record.Entry.IsDirectory {
+				isDir = "true"
+			}
+
+			var size int64
+			for _, chunk := range record.Entry.Chunks {
+				size += int64(chunk.Size)
+			}
+
+			sizeStr := fmt.Sprintf("%d", size)
+			if size == 0 && !record.Entry.IsDirectory {
+				sizeStr = "0"
+			} else if record.Entry.IsDirectory {
+				sizeStr = "-"
+			}
+
+			details := fmt.Sprintf("chunks:%d", len(record.Entry.Chunks))
+			if record.Entry.Attributes != nil {
+				details += fmt.Sprintf(" mode:%o", record.Entry.Attributes.FileMode)
+				if record.Entry.Attributes.Uid > 0 {
+					details += fmt.Sprintf(" uid:%d", record.Entry.Attributes.Uid)
+				}
+				if record.Entry.Attributes.Gid > 0 {
+					details += fmt.Sprintf(" gid:%d", record.Entry.Attributes.Gid)
+				}
+			}
+
+			fmt.Fprintf(writer, "%-30s %-30s %-50s %-8s %-12s %s\n",
+				deleteTimeStr, createTimeStr, record.Path, isDir, sizeStr, details)
+
+			// Show chunk details if requested and verbose
+			if *verbose && len(record.Entry.Chunks) > 0 {
+				for _, chunk := range record.Entry.Chunks {
+					fmt.Fprintf(writer, "    chunk: fileId=%s offset=%d size=%d\n",
+						chunk.FileId, chunk.Offset, chunk.Size)
+				}
+			}
+		} else {
+			fmt.Fprintf(writer, "%-30s %-30s %s\n", deleteTimeStr, createTimeStr, record.Path)
+		}
+	}
+}

--- a/unmaintained/log_recover/README.md
+++ b/unmaintained/log_recover/README.md
@@ -1,0 +1,39 @@
+# Log Recover Tool
+
+从 SeaweedFS filer log 文件恢复 filer entries 的工具。支持log完整目录恢复。
+
+## 功能特性
+
+### 核心功能
+- 读取和解析 filer log 文件
+- 重放文件事件（create, update, delete）
+- 构建最终的 filer entries 状态
+- 生成与 `fs.meta.save` 兼容的 meta 文件
+- 支持跳过已删除的文件
+- 详细的处理日志输出
+
+### 完整的恢复工具链
+1. **日志下载** (`download_logs`): 从 SeaweedFS filer 下载完整的 log 目录
+2. **完整目录恢复** (`log_recover_all`): 从整个 log 目录恢复，支持跨文件事件合并
+
+### 高级特性
+- **跨文件事件合并**: 自动合并同一文件在不同 log 文件中的事件
+- **时间序列处理**: 按时间戳正确排序和处理所有事件
+- **内存优化**: 支持大型数据集的批处理和内存限制
+- **完整的 chunk 重建**: 正确重建文件的所有数据块信息
+
+## 使用方法
+
+### 基本用法
+
+```bash
+# 1. 下载所有 log 文件
+./download_logs -filer=http://192.168.2.39:8888 -output=downloaded_logs -v
+
+# 2. 从下载的 logs 恢复
+./log_recover_all -logdir=downloaded_logs -output=recovered.meta -v
+
+# 3. 恢复到 filer
+weed shell
+> fs.meta.load recovered.meta
+```

--- a/unmaintained/log_recover/log_recover_all.go
+++ b/unmaintained/log_recover/log_recover_all.go
@@ -1,0 +1,649 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"io"
+	"log"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+
+	"google.golang.org/protobuf/proto"
+
+	"github.com/seaweedfs/seaweedfs/weed/pb/filer_pb"
+	"github.com/seaweedfs/seaweedfs/weed/util"
+	util_http "github.com/seaweedfs/seaweedfs/weed/util/http"
+)
+
+var (
+	logDir         = flag.String("logdir", "", "log directory path (e.g., /topics/.system/log)")
+	outputMetaFile = flag.String("output", "", "output meta file path (default: auto-generated)")
+	verbose        = flag.Bool("v", false, "verbose output")
+	skipDeleted    = flag.Bool("skip-deleted", true, "skip deleted files")
+	maxMemoryMB    = flag.Int("max-memory", 2048, "maximum memory usage in MB (for large datasets)")
+	batchSize      = flag.Int("batch-size", 10000, "batch size for processing events")
+)
+
+// EventType represents the type of file event
+type EventType int
+
+const (
+	EventCreate EventType = iota
+	EventUpdate
+	EventDelete
+)
+
+func (e EventType) String() string {
+	switch e {
+	case EventCreate:
+		return "CREATE"
+	case EventUpdate:
+		return "UPDATE"
+	case EventDelete:
+		return "DELETE"
+	default:
+		return "UNKNOWN"
+	}
+}
+
+// LogFile represents a single log file with metadata
+type LogFile struct {
+	Path    string
+	Name    string
+	ModTime time.Time
+	Size    int64
+}
+
+// CompleteFileState tracks the complete state of a file across all log files
+type CompleteFileState struct {
+	Path            string
+	FirstCreateTime int64
+	LastUpdateTime  int64
+	FinalEntry      *filer_pb.Entry
+	AllChunks       map[string]*filer_pb.FileChunk // key: chunk unique identifier
+	TotalSize       uint64
+	IsDeleted       bool
+	EventCount      int
+	LastSeenLogFile string
+}
+
+// EventWithSource represents an event with its source log file
+type EventWithSource struct {
+	Event     *filer_pb.SubscribeMetadataResponse
+	Timestamp int64
+	LogFile   string
+	FilePath  string
+}
+
+func main() {
+	flag.Parse()
+	util_http.InitGlobalHttpClient()
+
+	if *logDir == "" {
+		log.Fatal("log directory is required")
+	}
+
+	if *verbose {
+		fmt.Printf("Starting log recovery from directory: %s\n", *logDir)
+		fmt.Printf("Max memory usage: %d MB\n", *maxMemoryMB)
+		fmt.Printf("Batch size: %d events\n", *batchSize)
+	}
+
+	// Discover and sort log files
+	logFiles, err := discoverLogFiles(*logDir)
+	if err != nil {
+		log.Fatalf("failed to discover log files: %v", err)
+	}
+
+	if len(logFiles) == 0 {
+		log.Fatalf("no log files found in directory: %s", *logDir)
+	}
+
+	if *verbose {
+		fmt.Printf("Found %d log files\n", len(logFiles))
+		for i, lf := range logFiles {
+			fmt.Printf("  %d. %s (size: %d bytes, mtime: %s)\n",
+				i+1, lf.Name, lf.Size, lf.ModTime.Format(time.RFC3339))
+		}
+	}
+
+	// Process all log files to build complete file states
+	completeStates, err := processAllLogFiles(logFiles)
+	if err != nil {
+		log.Fatalf("failed to process log files: %v", err)
+	}
+
+	if *verbose {
+		fmt.Printf("Processed %d unique files\n", len(completeStates))
+	}
+
+	// Build final filer entries
+	filerEntries, err := buildCompleteEntries(completeStates)
+	if err != nil {
+		log.Fatalf("failed to build complete entries: %v", err)
+	}
+
+	if *verbose {
+		fmt.Printf("Final entries to save: %d\n", len(filerEntries))
+	}
+
+	// Generate output meta file
+	outputFileName := *outputMetaFile
+	if outputFileName == "" {
+		t := time.Now()
+		outputFileName = fmt.Sprintf("log-recover-%04d%02d%02d-%02d%02d%02d.meta",
+			t.Year(), t.Month(), t.Day(), t.Hour(), t.Minute(), t.Second())
+	}
+
+	err = saveMetaFile(outputFileName, filerEntries)
+	if err != nil {
+		log.Fatalf("failed to save meta file %s: %v", outputFileName, err)
+	}
+
+	fmt.Printf("Successfully recovered %d entries from %d log files and saved to %s\n",
+		len(filerEntries), len(logFiles), outputFileName)
+
+	// Print summary statistics
+	printSummaryStats(completeStates, filerEntries)
+}
+
+// discoverLogFiles finds and sorts all log files in the directory
+func discoverLogFiles(logDir string) ([]*LogFile, error) {
+	var logFiles []*LogFile
+
+	err := filepath.Walk(logDir, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+
+		// Skip directories and hidden files
+		if info.IsDir() || strings.HasPrefix(info.Name(), ".") {
+			return nil
+		}
+
+		// Skip files that are clearly not log files (e.g., .go files)
+		if strings.HasSuffix(info.Name(), ".go") ||
+			strings.HasSuffix(info.Name(), ".md") ||
+			strings.HasSuffix(info.Name(), ".meta") {
+			return nil
+		}
+
+		logFile := &LogFile{
+			Path:    path,
+			Name:    info.Name(),
+			ModTime: info.ModTime(),
+			Size:    info.Size(),
+		}
+
+		logFiles = append(logFiles, logFile)
+		return nil
+	})
+
+	if err != nil {
+		return nil, err
+	}
+
+	// Sort log files by modification time to ensure chronological processing
+	sort.Slice(logFiles, func(i, j int) bool {
+		return logFiles[i].ModTime.Before(logFiles[j].ModTime)
+	})
+
+	return logFiles, nil
+}
+
+func processAllLogFiles(logFiles []*LogFile) (map[string]*CompleteFileState, error) {
+	completeStates := make(map[string]*CompleteFileState)
+	totalEvents := 0
+
+	for _, logFile := range logFiles {
+		if *verbose {
+			fmt.Printf("Processing log file: %s\n", logFile.Name)
+		}
+
+		events, err := readEventsFromLogFile(logFile.Path)
+		if err != nil {
+			log.Printf("Warning: failed to read events from %s: %v", logFile.Path, err)
+			continue
+		}
+
+		if *verbose {
+			fmt.Printf("  Found %d events\n", len(events))
+		}
+
+		// Process events in batches to manage memory
+		err = processEventsInBatches(events, logFile.Name, completeStates)
+		if err != nil {
+			return nil, fmt.Errorf("failed to process events from %s: %v", logFile.Name, err)
+		}
+
+		totalEvents += len(events)
+	}
+
+	if *verbose {
+		fmt.Printf("Total events processed: %d\n", totalEvents)
+	}
+
+	return completeStates, nil
+}
+
+func readEventsFromLogFile(filePath string) ([]*EventWithSource, error) {
+	dst, err := os.OpenFile(filePath, os.O_RDONLY, 0644)
+	if err != nil {
+		return nil, err
+	}
+	defer dst.Close()
+
+	var events []*EventWithSource
+	sizeBuf := make([]byte, 4)
+
+	for {
+		if n, err := dst.Read(sizeBuf); n != 4 {
+			if err == io.EOF {
+				break
+			}
+			return nil, err
+		}
+
+		size := util.BytesToUint32(sizeBuf)
+		data := make([]byte, int(size))
+
+		if n, err := dst.Read(data); n != len(data) {
+			return nil, err
+		}
+
+		logEntry := &filer_pb.LogEntry{}
+		err := proto.Unmarshal(data, logEntry)
+		if err != nil {
+			log.Printf("Warning: failed to unmarshal LogEntry: %v", err)
+			continue
+		}
+
+		event := &filer_pb.SubscribeMetadataResponse{}
+		err = proto.Unmarshal(logEntry.Data, event)
+		if err != nil {
+			log.Printf("Warning: failed to unmarshal SubscribeMetadataResponse: %v", err)
+			continue
+		}
+
+		// Extract file path from the event
+		filePath := extractFilePathFromEvent(event)
+		if filePath == "" {
+			continue // Skip events without valid file paths
+		}
+
+		eventWithSource := &EventWithSource{
+			Event:     event,
+			Timestamp: logEntry.TsNs,
+			LogFile:   filepath.Base(filePath),
+			FilePath:  filePath,
+		}
+
+		events = append(events, eventWithSource)
+	}
+
+	return events, nil
+}
+
+// extractFilePathFromEvent extracts the file path from an event
+func extractFilePathFromEvent(event *filer_pb.SubscribeMetadataResponse) string {
+	var fileName string
+
+	if event.EventNotification.NewEntry != nil {
+		fileName = event.EventNotification.NewEntry.Name
+	} else if event.EventNotification.OldEntry != nil {
+		fileName = event.EventNotification.OldEntry.Name
+	} else {
+		return ""
+	}
+
+	// Construct full path
+	dir := strings.TrimSuffix(event.Directory, "/")
+	if dir == "" {
+		dir = "/"
+	} else if !strings.HasPrefix(dir, "/") {
+		dir = "/" + dir
+	}
+
+	return filepath.Join(dir, fileName)
+}
+
+// processEventsInBatches processes events in batches to manage memory usage
+func processEventsInBatches(events []*EventWithSource, logFileName string, completeStates map[string]*CompleteFileState) error {
+	for i := 0; i < len(events); i += *batchSize {
+		end := i + *batchSize
+		if end > len(events) {
+			end = len(events)
+		}
+
+		batch := events[i:end]
+		err := processBatchEvents(batch, logFileName, completeStates)
+		if err != nil {
+			return err
+		}
+
+		// Force garbage collection for large datasets
+		if i > 0 && i%(*batchSize*10) == 0 {
+			if *verbose {
+				fmt.Printf("  Processed %d events from %s\n", i, logFileName)
+			}
+		}
+	}
+
+	return nil
+}
+
+// processBatchEvents processes a batch of events
+func processBatchEvents(events []*EventWithSource, logFileName string, completeStates map[string]*CompleteFileState) error {
+	for _, eventWithSource := range events {
+		err := processEvent(eventWithSource, logFileName, completeStates)
+		if err != nil {
+			log.Printf("Warning: failed to process event: %v", err)
+			continue
+		}
+	}
+	return nil
+}
+
+// processEvent processes a single event and updates the complete file state
+func processEvent(eventWithSource *EventWithSource, logFileName string, completeStates map[string]*CompleteFileState) error {
+	event := eventWithSource.Event
+	filePath := eventWithSource.FilePath
+
+	// Get or create complete file state
+	if completeStates[filePath] == nil {
+		completeStates[filePath] = &CompleteFileState{
+			Path:            filePath,
+			AllChunks:       make(map[string]*filer_pb.FileChunk),
+			FirstCreateTime: eventWithSource.Timestamp,
+		}
+	}
+
+	state := completeStates[filePath]
+	state.EventCount++
+	state.LastSeenLogFile = logFileName
+	state.LastUpdateTime = eventWithSource.Timestamp
+
+	var eventType EventType
+	var entry *filer_pb.Entry
+
+	switch {
+	case event.EventNotification.NewEntry != nil && event.EventNotification.OldEntry == nil:
+		// File create
+		eventType = EventCreate
+		entry = event.EventNotification.NewEntry
+		if state.FirstCreateTime > eventWithSource.Timestamp {
+			state.FirstCreateTime = eventWithSource.Timestamp
+		}
+
+	case event.EventNotification.NewEntry != nil && event.EventNotification.OldEntry != nil:
+		// File update
+		eventType = EventUpdate
+		entry = event.EventNotification.NewEntry
+
+	case event.EventNotification.NewEntry == nil && event.EventNotification.OldEntry != nil:
+		// File delete
+		eventType = EventDelete
+		entry = event.EventNotification.OldEntry
+		state.IsDeleted = true
+		if *verbose {
+			fmt.Printf("[DELETE] %s: %s (from %s)\n",
+				time.Unix(0, eventWithSource.Timestamp).Format(time.RFC3339),
+				filePath, logFileName)
+		}
+		return nil
+
+	default:
+		// Unknown event, skip
+		return nil
+	}
+
+	// Update the final entry state
+	state.FinalEntry = cloneEntry(entry)
+
+	// Merge chunks from this event
+	err := mergeChunksIntoState(state, entry.Chunks, eventWithSource.Timestamp)
+	if err != nil {
+		return err
+	}
+
+	if *verbose && eventType == EventCreate {
+		fmt.Printf("[CREATE] %s: %s (from %s)\n",
+			time.Unix(0, eventWithSource.Timestamp).Format(time.RFC3339),
+			filePath, logFileName)
+	} else if *verbose && eventType == EventUpdate {
+		fmt.Printf("[UPDATE] %s: %s (%d chunks from %s)\n",
+			time.Unix(0, eventWithSource.Timestamp).Format(time.RFC3339),
+			filePath, len(entry.Chunks), logFileName)
+	}
+
+	return nil
+}
+
+// mergeChunksIntoState merges chunks from an event into the complete file state
+func mergeChunksIntoState(state *CompleteFileState, chunks []*filer_pb.FileChunk, timestamp int64) error {
+	for _, chunk := range chunks {
+		// Create a unique key for this chunk based on offset
+		chunkKey := fmt.Sprintf("offset_%d", chunk.Offset)
+
+		// Clone the chunk to avoid reference issues
+		clonedChunk := cloneChunk(chunk)
+
+		// If we already have a chunk at this offset, use the newer one
+		if existingChunk, exists := state.AllChunks[chunkKey]; exists {
+			if clonedChunk.ModifiedTsNs > existingChunk.ModifiedTsNs {
+				state.AllChunks[chunkKey] = clonedChunk
+			}
+		} else {
+			state.AllChunks[chunkKey] = clonedChunk
+		}
+	}
+
+	// Recalculate total size
+	state.TotalSize = 0
+	for _, chunk := range state.AllChunks {
+		if chunk.Offset+int64(chunk.Size) > int64(state.TotalSize) {
+			state.TotalSize = uint64(chunk.Offset + int64(chunk.Size))
+		}
+	}
+
+	return nil
+}
+
+// cloneEntry creates a deep copy of an entry
+func cloneEntry(original *filer_pb.Entry) *filer_pb.Entry {
+	cloned := &filer_pb.Entry{
+		Name:        original.Name,
+		IsDirectory: original.IsDirectory,
+		Extended:    make(map[string][]byte),
+	}
+
+	// Clone attributes
+	if original.Attributes != nil {
+		cloned.Attributes = &filer_pb.FuseAttributes{
+			FileSize:      original.Attributes.FileSize,
+			Mtime:         original.Attributes.Mtime,
+			FileMode:      original.Attributes.FileMode,
+			Uid:           original.Attributes.Uid,
+			Gid:           original.Attributes.Gid,
+			Crtime:        original.Attributes.Crtime,
+			Mime:          original.Attributes.Mime,
+			TtlSec:        original.Attributes.TtlSec,
+			UserName:      original.Attributes.UserName,
+			GroupName:     append([]string{}, original.Attributes.GroupName...),
+			SymlinkTarget: original.Attributes.SymlinkTarget,
+			Md5:           append([]byte{}, original.Attributes.Md5...),
+			Rdev:          original.Attributes.Rdev,
+			Inode:         original.Attributes.Inode,
+		}
+	}
+
+	// Clone extended attributes
+	for k, v := range original.Extended {
+		cloned.Extended[k] = append([]byte{}, v...)
+	}
+
+	// Note: Chunks will be set separately from the merged state
+	return cloned
+}
+
+// cloneChunk creates a deep copy of a chunk
+func cloneChunk(original *filer_pb.FileChunk) *filer_pb.FileChunk {
+	cloned := &filer_pb.FileChunk{
+		FileId:          original.FileId,
+		Offset:          original.Offset,
+		Size:            original.Size,
+		ModifiedTsNs:    original.ModifiedTsNs,
+		ETag:            original.ETag,
+		SourceFileId:    original.SourceFileId,
+		CipherKey:       append([]byte{}, original.CipherKey...),
+		IsCompressed:    original.IsCompressed,
+		IsChunkManifest: original.IsChunkManifest,
+	}
+
+	// Clone FID
+	if original.Fid != nil {
+		cloned.Fid = &filer_pb.FileId{
+			VolumeId: original.Fid.VolumeId,
+			FileKey:  original.Fid.FileKey,
+			Cookie:   original.Fid.Cookie,
+		}
+	}
+
+	// Clone source FID
+	if original.SourceFid != nil {
+		cloned.SourceFid = &filer_pb.FileId{
+			VolumeId: original.SourceFid.VolumeId,
+			FileKey:  original.SourceFid.FileKey,
+			Cookie:   original.SourceFid.Cookie,
+		}
+	}
+
+	return cloned
+}
+
+func buildCompleteEntries(completeStates map[string]*CompleteFileState) ([]*filer_pb.FullEntry, error) {
+	var filerEntries []*filer_pb.FullEntry
+
+	for filePath, state := range completeStates {
+		// Skip deleted files if requested
+		if *skipDeleted && state.IsDeleted {
+			if *verbose {
+				fmt.Printf("Skipping deleted file: %s\n", filePath)
+			}
+			continue
+		}
+
+		if state.FinalEntry == nil {
+			if *verbose {
+				fmt.Printf("Warning: no final entry for %s, skipping\n", filePath)
+			}
+			continue
+		}
+
+		// Build the complete entry with all chunks
+		completeEntry := cloneEntry(state.FinalEntry)
+
+		// Set chunks from the merged state
+		var allChunks []*filer_pb.FileChunk
+		for _, chunk := range state.AllChunks {
+			allChunks = append(allChunks, chunk)
+		}
+
+		// Sort chunks by offset
+		sort.Slice(allChunks, func(i, j int) bool {
+			return allChunks[i].Offset < allChunks[j].Offset
+		})
+
+		completeEntry.Chunks = allChunks
+
+		// Update file size in attributes to match actual chunks
+		if completeEntry.Attributes != nil {
+			completeEntry.Attributes.FileSize = state.TotalSize
+		}
+
+		// Extract directory and file name from path
+		dir := "/"
+		fileName := strings.TrimPrefix(filePath, "/")
+
+		if lastSlash := strings.LastIndex(fileName, "/"); lastSlash >= 0 {
+			dir = "/" + fileName[:lastSlash]
+			fileName = fileName[lastSlash+1:]
+		}
+
+		completeEntry.Name = fileName
+
+		fullEntry := &filer_pb.FullEntry{
+			Dir:   dir,
+			Entry: completeEntry,
+		}
+
+		filerEntries = append(filerEntries, fullEntry)
+	}
+
+	return filerEntries, nil
+}
+
+// saveMetaFile saves filer entries to meta file format
+func saveMetaFile(fileName string, filerEntries []*filer_pb.FullEntry) error {
+	dst, err := os.OpenFile(fileName, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0644)
+	if err != nil {
+		return fmt.Errorf("failed to create file %s: %v", fileName, err)
+	}
+	defer dst.Close()
+
+	sizeBuf := make([]byte, 4)
+
+	for _, fullEntry := range filerEntries {
+		bytes, err := proto.Marshal(fullEntry)
+		if err != nil {
+			return fmt.Errorf("marshal error for entry %s/%s: %v", fullEntry.Dir, fullEntry.Entry.Name, err)
+		}
+
+		util.Uint32toBytes(sizeBuf, uint32(len(bytes)))
+		if _, err := dst.Write(sizeBuf); err != nil {
+			return err
+		}
+		if _, err := dst.Write(bytes); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// printSummaryStats prints summary statistics
+func printSummaryStats(completeStates map[string]*CompleteFileState, filerEntries []*filer_pb.FullEntry) {
+	fmt.Printf("\n=== Recovery Summary ===\n")
+
+	var totalEvents, deletedFiles, activeFiles int
+	var totalSize uint64
+	var dirCount, fileCount int
+
+	for _, state := range completeStates {
+		totalEvents += state.EventCount
+		if state.IsDeleted {
+			deletedFiles++
+		} else {
+			activeFiles++
+			totalSize += state.TotalSize
+		}
+	}
+
+	for _, entry := range filerEntries {
+		if entry.Entry.IsDirectory {
+			dirCount++
+		} else {
+			fileCount++
+		}
+	}
+
+	fmt.Printf("Total unique files tracked: %d\n", len(completeStates))
+	fmt.Printf("Total events processed: %d\n", totalEvents)
+	fmt.Printf("Active files: %d\n", activeFiles)
+	fmt.Printf("Deleted files: %d\n", deletedFiles)
+	fmt.Printf("Final entries saved: %d (directories: %d, files: %d)\n", len(filerEntries), dirCount, fileCount)
+	fmt.Printf("Total recovered data size: %.2f MB\n", float64(totalSize)/(1024*1024))
+}

--- a/unmaintained/recover_chunk/recover_chunk.go
+++ b/unmaintained/recover_chunk/recover_chunk.go
@@ -1,0 +1,196 @@
+package main
+
+import (
+	"encoding/binary"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"path"
+	"time"
+
+	"github.com/seaweedfs/seaweedfs/weed/glog"
+	"github.com/seaweedfs/seaweedfs/weed/storage/backend"
+	"github.com/seaweedfs/seaweedfs/weed/storage/needle"
+	"github.com/seaweedfs/seaweedfs/weed/storage/super_block"
+	"github.com/seaweedfs/seaweedfs/weed/storage/types"
+	"github.com/seaweedfs/seaweedfs/weed/util"
+	util_http "github.com/seaweedfs/seaweedfs/weed/util/http"
+)
+
+var (
+	volumeDir        = flag.String("dir", "/tmp", "data directory")
+	volumeCollection = flag.String("collection", "", "volume collection name")
+	volumeId         = flag.Int("volumeId", -1, "volume id")
+	targetFileKey    = flag.Uint64("fileKey", 0, "needle file key to recover (decimal)")
+	targetCookie     = flag.Uint64("cookie", 0, "needle cookie (decimal)")
+	dryRun           = flag.Bool("dry-run", false, "only scan and print, do not write idx")
+)
+
+/*
+
+Recover a lost chunk by scanning the .dat file for a needle with matching
+fileKey+cookie and appending the correct entry to the .idx file.
+
+Usage:
+
+	# 1. Dry-run: scan and verify the needle exists
+	go run recover_chunk.go -dir=/data -volumeId=2191276 -fileKey=646160384 -cookie=4116679282 -dry-run
+
+	# 2. Recover: write found entry to .idx_recovered
+	go run recover_chunk.go -dir=/data -volumeId=2191276 -fileKey=646160384 -cookie=4116679282
+
+	# 3. Replace original .idx after verification
+	mv 2191276.idx_recovered 2191276.idx
+*/
+func main() {
+	flag.Parse()
+	util_http.InitGlobalHttpClient()
+
+	if *volumeId < 0 || *targetFileKey == 0 {
+		glog.Fatalf("Usage: recover_chunk -dir=/path -volumeId=N -fileKey=KEY -cookie=COOKIE")
+	}
+
+	fileName := fmt.Sprintf("%d", *volumeId)
+	if *volumeCollection != "" {
+		fileName = *volumeCollection + "_" + fileName
+	}
+
+	datPath := path.Join(*volumeDir, fileName+".dat")
+	idxPath := path.Join(*volumeDir, fileName+".idx")
+
+	datFile, err := os.OpenFile(datPath, os.O_RDONLY, 0644)
+	if err != nil {
+		glog.Fatalf("Open .dat %s: %v", datPath, err)
+	}
+	defer datFile.Close()
+
+	datBackend := backend.NewDiskFile(datFile)
+	defer datBackend.Close()
+
+	// Read superblock
+	superBlock, err := super_block.ReadSuperBlock(datBackend)
+	if err != nil {
+		glog.Fatalf("Read superblock: %v", err)
+	}
+	fmt.Printf("Volume %d, version=%d, replica=%v, ttl=%v\n",
+		*volumeId, superBlock.Version, superBlock.ReplicaPlacement, superBlock.Ttl)
+
+	version := superBlock.Version
+	targetId := types.NeedleId(*targetFileKey)
+	targetCook := types.Cookie(uint32(*targetCookie))
+
+	// Scan .dat file for the target needle
+	offset := int64(superBlock.BlockSize())
+	totalNeedles := 0
+	found := false
+
+	for {
+		n, _, bodyLen, err := needle.ReadNeedleHeader(datBackend, version, offset)
+		if err != nil {
+			if err == io.EOF {
+				break
+			}
+			fmt.Printf("ReadNeedleHeader error at offset %d: %v\n", offset, err)
+			break
+		}
+		if n == nil || bodyLen < 0 {
+			break
+		}
+
+		totalNeedles++
+
+		if n.Id == targetId && n.Cookie == targetCook {
+			// Found the needle
+			found = true
+			fmt.Printf("\n=== FOUND ===\n")
+			fmt.Printf("  NeedleId: %d (0x%x)\n", n.Id, n.Id)
+			fmt.Printf("  Cookie:   %d (0x%08x)\n", n.Cookie, n.Cookie)
+			fmt.Printf("  Offset:   %d (actual), %d (idx)\n", offset, offset/int64(types.NeedlePaddingSize))
+			fmt.Printf("  Size:     %d (%s)\n", n.Size, util.BytesToHumanReadable(uint64(n.Size)))
+
+			// Try to read body for more info
+			if n.Size > 0 && n.Size != types.TombstoneFileSize {
+				n.ReadNeedleBody(datBackend, version, offset+int64(types.NeedleHeaderSize), bodyLen)
+				fmt.Printf("  DataSize: %d\n", n.DataSize)
+				fmt.Printf("  Name:     %s\n", string(n.Name))
+				if n.AppendAtNs > 0 {
+					t := time.Unix(0, int64(n.AppendAtNs))
+					fmt.Printf("  Appended: %v\n", t)
+				}
+				fmt.Printf("  Checksum: %d\n", n.Checksum)
+			}
+			fmt.Printf("============\n")
+
+			if !*dryRun {
+				if err := appendIdxEntry(idxPath, n.Id, offset, n.Size); err != nil {
+					glog.Fatalf("Write idx entry: %v", err)
+				}
+			}
+			break
+		}
+
+		offset += int64(types.NeedleHeaderSize) + bodyLen
+	}
+
+	fmt.Printf("\nScan complete: %d needles scanned\n", totalNeedles)
+	if !found {
+		fmt.Printf("ERROR: needle fileKey=%d cookie=%d NOT FOUND in .dat\n", targetId, targetCook)
+		os.Exit(1)
+	}
+	if *dryRun {
+		fmt.Println("Dry-run: no changes written")
+	}
+}
+
+func appendIdxEntry(idxPath string, needleId types.NeedleId, actualOffset int64, size types.Size) error {
+	outPath := idxPath + "_recovered"
+
+	// Copy existing .idx to .idx_recovered
+	src, err := os.Open(idxPath)
+	if err != nil {
+		return fmt.Errorf("open src idx: %v", err)
+	}
+	defer src.Close()
+
+	dst, err := os.Create(outPath)
+	if err != nil {
+		return fmt.Errorf("create %s: %v", outPath, err)
+	}
+	defer dst.Close()
+
+	if _, err := io.Copy(dst, src); err != nil {
+		return fmt.Errorf("copy idx: %v", err)
+	}
+
+	// Append new entry
+	entry := make([]byte, types.NeedleIdSize+types.OffsetSize+types.SizeSize)
+	types.NeedleIdToBytes(entry[0:types.NeedleIdSize], needleId)
+	idxOffset := types.ToOffset(actualOffset)
+	types.OffsetToBytes(entry[types.NeedleIdSize:types.NeedleIdSize+types.OffsetSize], idxOffset)
+	types.SizeToBytes(entry[types.NeedleIdSize+types.OffsetSize:], size)
+
+	// Verify by reading back
+	key2 := types.BytesToNeedleId(entry[0:types.NeedleIdSize])
+	offset2 := types.BytesToOffset(entry[types.NeedleIdSize : types.NeedleIdSize+types.OffsetSize])
+	size2 := types.BytesToSize(entry[types.NeedleIdSize+types.OffsetSize:])
+	fmt.Printf("  Writing idx entry: key=%d offset=%d(actual=%d) size=%d\n",
+		key2, offset2.ToActualOffset(), offset2.ToActualOffset(), size2)
+
+	// Double check actual offset matches
+	if offset2.ToActualOffset() != actualOffset {
+		return fmt.Errorf("offset mismatch: encoded %d != actual %d", offset2.ToActualOffset(), actualOffset)
+	}
+
+	// Check size is not negative (tombstone)
+	if binary.BigEndian.Uint32(entry[types.NeedleIdSize+types.OffsetSize:]) != uint32(size) {
+		fmt.Printf("  Warning: size encoding check: expected %d, got encoded bytes that decode back correctly\n", size)
+	}
+
+	if _, err := dst.Write(entry); err != nil {
+		return fmt.Errorf("write entry: %v", err)
+	}
+
+	fmt.Printf("  Appended to %s\n", outPath)
+	return nil
+}

--- a/unmaintained/see_log_entry/see_log_entry.go
+++ b/unmaintained/see_log_entry/see_log_entry.go
@@ -78,14 +78,28 @@ func walkLogEntryFile(dst *os.File) error {
 		switch {
 		case event.EventNotification.NewEntry != nil && event.EventNotification.OldEntry == nil:
 			fmt.Printf("file create, dir: %s: file: %+s, ts: %d, time: %s\n", event.Directory, event.EventNotification.NewEntry.Name, event.TsNs, timeStr)
+			displayLogEntry(event.EventNotification.NewEntry)
 		case event.EventNotification.NewEntry != nil && event.EventNotification.OldEntry != nil:
 			fmt.Printf("file update: dir: %s, file: %+s, ts: %d, time: %s\n", event.Directory, event.EventNotification.NewEntry.Name, event.TsNs, timeStr)
+			displayLogEntry(event.EventNotification.NewEntry)
 		case event.EventNotification.NewEntry == nil && event.EventNotification.OldEntry != nil:
 			fmt.Printf("file delete: dir: %s, file: %+s, ts: %d, time: %s\n", event.Directory, event.EventNotification.OldEntry.Name, event.TsNs, timeStr)
+			displayLogEntry(event.EventNotification.OldEntry)
 		case event.EventNotification.NewEntry == nil && event.EventNotification.OldEntry != nil:
 		default:
 			fmt.Printf("Unknown event: %v\n", event)
 		}
 	}
 
+}
+
+func displayLogEntry(entry *filer_pb.Entry) {
+	fmt.Printf("----name: %s, is_directory: %t, chunks: %d, attributes: %v\n",
+		entry.Name, entry.IsDirectory, len(entry.Chunks), entry.Attributes)
+
+	if len(entry.Chunks) > 0 {
+		for _, chunk := range entry.Chunks {
+			fmt.Printf("---------chunk: fileId: %s, file_offset: %d, size: %d, fid: %v, etag: %s\n", chunk.FileId, chunk.Offset, chunk.Size, chunk.Fid, chunk.ETag)
+		}
+	}
 }


### PR DESCRIPTION
# What problem are we solving?
data loss happens when metadata disk was accidentally formatted, causing 1.8 million files loss because rocksdb data was cleared


# How are we solving the problem?
the filer logs are still in data disk, all filer entries can be replayed from filer logs


# How is the PR tested?

test log:
```
=== Download Complete ===
Successfully downloaded: 22/22 files
Failed downloads: 0
Total size downloaded: 1527.23 MB
Total time: 1.758707155s
Average speed: 868.38 MB/s

✅ All files downloaded successfully!
You can now run: ./log_recover_full -logdir=/home/bruce/Data/debug/weed/log39



./log_recover_all -logdir=/home/bruce/Data/debug/weed/log39
Successfully recovered 326508 entries from 18 log files and saved to log-recover-20250922-214614.meta

=== Recovery Summary ===
Total unique files tracked: 2458504
Total events processed: 4590500
Active files: 326508
Deleted files: 2131996
Final entries saved: 326508 (directories: 5, files: 326503)
Total recovered data size: 273.33 MB
```


# Checks
- [ ] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.
