### PR TITLE
rendezvous hash to pick vol server

### DIFF
--- a/weed/filer/reader_at.go
+++ b/weed/filer/reader_at.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"hash/fnv"
 	"io"
-	"math/rand"
 	"slices"
 	"sync"
 
@@ -86,27 +85,17 @@ func LookupFn(filerClient filer_pb.FilerClient) wdclient.LookupFileIdFunctionTyp
 			}
 			serverOfUrl[targetUrl] = volumeServerAddress
 		}
-		if len(localUrls) == 0 {
-			// if all loc are remote,
-			// use a deterministic ordering based on volserver and vid
-			// so that no need to download from remote multipe times
-			// vid is included for even distribution
+		// use a deterministic ordering based on volserver and vid
+		// so that no need to download from remote multipe times
+		// vid is included for even distribution
 
-			deterministicSort(sameDcTargetUrls, serverOfUrl, vid)
-			deterministicSort(otherTargetUrls, serverOfUrl, vid)
-		} else {
-			rand.Shuffle(len(sameDcTargetUrls), func(i, j int) {
-				sameDcTargetUrls[i], sameDcTargetUrls[j] = sameDcTargetUrls[j], sameDcTargetUrls[i]
-			})
-			rand.Shuffle(len(otherTargetUrls), func(i, j int) {
-				otherTargetUrls[i], otherTargetUrls[j] = otherTargetUrls[j], otherTargetUrls[i]
-			})
-			if len(localUrls) != len(sameDcTargetUrls) {
-				sameDcTargetUrls = util.ReorderToFront(localUrls, sameDcTargetUrls)
-			}
-			if len(localUrls) != len(otherTargetUrls) {
-				otherTargetUrls = util.ReorderToFront(localUrls, otherTargetUrls)
-			}
+		deterministicSort(sameDcTargetUrls, serverOfUrl, vid)
+		deterministicSort(otherTargetUrls, serverOfUrl, vid)
+		if len(localUrls) > 0 && len(localUrls) != len(sameDcTargetUrls) {
+			sameDcTargetUrls = util.ReorderToFront(localUrls, sameDcTargetUrls)
+		}
+		if len(localUrls) > 0 && len(localUrls) != len(otherTargetUrls) {
+			otherTargetUrls = util.ReorderToFront(localUrls, otherTargetUrls)
 		}
 		// Prefer same data center
 		targetUrls = append(sameDcTargetUrls, otherTargetUrls...)

--- a/weed/filer/reader_at.go
+++ b/weed/filer/reader_at.go
@@ -3,8 +3,10 @@ package filer
 import (
 	"context"
 	"fmt"
+	"hash/fnv"
 	"io"
 	"math/rand"
+	"slices"
 	"sync"
 
 	"github.com/seaweedfs/seaweedfs/weed/glog"
@@ -67,6 +69,7 @@ func LookupFn(filerClient filer_pb.FilerClient) wdclient.LookupFileIdFunctionTyp
 		fcDataCenter := filerClient.GetDataCenter()
 		var sameDcTargetUrls, otherTargetUrls []string
 		localUrls := make(map[string]bool)
+		urlOfServer := make(map[string]string)
 		for _, loc := range locations.Locations {
 			volumeServerAddress := filerClient.AdjustedUrl(loc)
 			targetUrl := fmt.Sprintf("http://%s/%s", volumeServerAddress, fileId)
@@ -80,23 +83,54 @@ func LookupFn(filerClient filer_pb.FilerClient) wdclient.LookupFileIdFunctionTyp
 			} else {
 				sameDcTargetUrls = append(sameDcTargetUrls, targetUrl)
 			}
+			urlOfServer[targetUrl] = volumeServerAddress
 		}
-		rand.Shuffle(len(sameDcTargetUrls), func(i, j int) {
-			sameDcTargetUrls[i], sameDcTargetUrls[j] = sameDcTargetUrls[j], sameDcTargetUrls[i]
-		})
-		rand.Shuffle(len(otherTargetUrls), func(i, j int) {
-			otherTargetUrls[i], otherTargetUrls[j] = otherTargetUrls[j], otherTargetUrls[i]
-		})
-		if len(localUrls) > 0 && len(localUrls) != len(sameDcTargetUrls) {
-			sameDcTargetUrls = util.ReorderToFront(localUrls, sameDcTargetUrls)
-		}
-		if len(localUrls) > 0 && len(localUrls) != len(otherTargetUrls) {
-			otherTargetUrls = util.ReorderToFront(localUrls, otherTargetUrls)
+		if len(localUrls) == 0 {
+			// if all loc are remote,
+			// use a deterministic ordering based on volserver and vid
+			// so that no need to download from remote multipe times
+			// vid is included for even distribution
+
+			deterministicSort(sameDcTargetUrls, urlOfServer, vid)
+			deterministicSort(otherTargetUrls, urlOfServer, vid)
+		} else {
+			rand.Shuffle(len(sameDcTargetUrls), func(i, j int) {
+				sameDcTargetUrls[i], sameDcTargetUrls[j] = sameDcTargetUrls[j], sameDcTargetUrls[i]
+			})
+			rand.Shuffle(len(otherTargetUrls), func(i, j int) {
+				otherTargetUrls[i], otherTargetUrls[j] = otherTargetUrls[j], otherTargetUrls[i]
+			})
+			if len(localUrls) != len(sameDcTargetUrls) {
+				sameDcTargetUrls = util.ReorderToFront(localUrls, sameDcTargetUrls)
+			}
+			if len(localUrls) != len(otherTargetUrls) {
+				otherTargetUrls = util.ReorderToFront(localUrls, otherTargetUrls)
+			}
 		}
 		// Prefer same data center
 		targetUrls = append(sameDcTargetUrls, otherTargetUrls...)
 		return
 	}
+}
+
+func deterministicSort(urls []string, urlOfServer map[string]string, vid string) {
+	urlsHash := make(map[string]uint64)
+	for _, url := range urls {
+		hasher := fnv.New64a()
+		hasher.Write([]byte(vid))
+		hasher.Write([]byte("#"))
+		hasher.Write([]byte(urlOfServer[url]))
+		urlsHash[url] = hasher.Sum64()
+	}
+	slices.SortFunc(urls, func(i, j string) int {
+		hi, hj := urlsHash[i], urlsHash[j]
+		if hi < hj {
+			return -1
+		} else if hi > hj {
+			return 1
+		}
+		return 0
+	})
 }
 
 func NewChunkReaderAtFromClient(readerCache *ReaderCache, chunkViews *IntervalList[*ChunkView], fileSize int64) *ChunkReadAt {

--- a/weed/filer/reader_at.go
+++ b/weed/filer/reader_at.go
@@ -1,6 +1,7 @@
 package filer
 
 import (
+	"cmp"
 	"context"
 	"fmt"
 	"hash/fnv"
@@ -115,27 +116,20 @@ func LookupFn(filerClient filer_pb.FilerClient) wdclient.LookupFileIdFunctionTyp
 
 func deterministicSort(urls []string, serverOfUrl map[string]string, vid string) {
 	urlsHash := make(map[string]uint64)
+	hasher := fnv.New64a()
 	for _, url := range urls {
-		hasher := fnv.New64a()
+		hasher.Reset()
 		hasher.Write([]byte(vid))
 		hasher.Write([]byte("#"))
 		hasher.Write([]byte(serverOfUrl[url]))
 		urlsHash[url] = hasher.Sum64()
 	}
-	slices.SortFunc(urls, func(i, j string) int {
-		hi, hj := urlsHash[i], urlsHash[j]
-		if hi < hj {
-			return -1
-		} else if hi > hj {
-			return 1
+	slices.SortFunc(urls, func(a, b string) int {
+		ha, hb := urlsHash[a], urlsHash[b]
+		if c := cmp.Compare(ha, hb); c != 0 {
+			return c
 		}
-		if i < j {
-			return -1
-		}
-		if i > j {
-			return 1
-		}
-		return 0
+		return cmp.Compare(a, b)
 	})
 }
 

--- a/weed/filer/reader_at.go
+++ b/weed/filer/reader_at.go
@@ -69,7 +69,7 @@ func LookupFn(filerClient filer_pb.FilerClient) wdclient.LookupFileIdFunctionTyp
 		fcDataCenter := filerClient.GetDataCenter()
 		var sameDcTargetUrls, otherTargetUrls []string
 		localUrls := make(map[string]bool)
-		urlOfServer := make(map[string]string)
+		serverOfUrl := make(map[string]string)
 		for _, loc := range locations.Locations {
 			volumeServerAddress := filerClient.AdjustedUrl(loc)
 			targetUrl := fmt.Sprintf("http://%s/%s", volumeServerAddress, fileId)
@@ -83,7 +83,7 @@ func LookupFn(filerClient filer_pb.FilerClient) wdclient.LookupFileIdFunctionTyp
 			} else {
 				sameDcTargetUrls = append(sameDcTargetUrls, targetUrl)
 			}
-			urlOfServer[targetUrl] = volumeServerAddress
+			serverOfUrl[targetUrl] = volumeServerAddress
 		}
 		if len(localUrls) == 0 {
 			// if all loc are remote,
@@ -91,8 +91,8 @@ func LookupFn(filerClient filer_pb.FilerClient) wdclient.LookupFileIdFunctionTyp
 			// so that no need to download from remote multipe times
 			// vid is included for even distribution
 
-			deterministicSort(sameDcTargetUrls, urlOfServer, vid)
-			deterministicSort(otherTargetUrls, urlOfServer, vid)
+			deterministicSort(sameDcTargetUrls, serverOfUrl, vid)
+			deterministicSort(otherTargetUrls, serverOfUrl, vid)
 		} else {
 			rand.Shuffle(len(sameDcTargetUrls), func(i, j int) {
 				sameDcTargetUrls[i], sameDcTargetUrls[j] = sameDcTargetUrls[j], sameDcTargetUrls[i]
@@ -113,13 +113,13 @@ func LookupFn(filerClient filer_pb.FilerClient) wdclient.LookupFileIdFunctionTyp
 	}
 }
 
-func deterministicSort(urls []string, urlOfServer map[string]string, vid string) {
+func deterministicSort(urls []string, serverOfUrl map[string]string, vid string) {
 	urlsHash := make(map[string]uint64)
 	for _, url := range urls {
 		hasher := fnv.New64a()
 		hasher.Write([]byte(vid))
 		hasher.Write([]byte("#"))
-		hasher.Write([]byte(urlOfServer[url]))
+		hasher.Write([]byte(serverOfUrl[url]))
 		urlsHash[url] = hasher.Sum64()
 	}
 	slices.SortFunc(urls, func(i, j string) int {
@@ -127,6 +127,12 @@ func deterministicSort(urls []string, urlOfServer map[string]string, vid string)
 		if hi < hj {
 			return -1
 		} else if hi > hj {
+			return 1
+		}
+		if i < j {
+			return -1
+		}
+		if i > j {
 			return 1
 		}
 		return 0


### PR DESCRIPTION
# What problem are we solving?
1. The url list is shuffled, so if all replicas are all remote, all replicas has chance to receive read request and trigger download from remote action. This is not proper b/c download from tape is a very expensive operation.

2. The vidCache in LookupFn() is not updated when we do a recall which change a location to remote, so that future read will have possibility to hit a replica without .dat file.


# How are we solving the problem?
If all loc are remote, use a deterministic ordering based on volserver and vid instead of shuffle, so that no need to download from remote multipe times. vid is included for even distribution


# How is the PR tested?



# Checks
- [ ] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.
