### PR TITLE
use ReadFull

### DIFF
--- a/weed/shell/command_fs_meta_load.go
+++ b/weed/shell/command_fs_meta_load.go
@@ -97,7 +97,7 @@ func (c *commandFsMetaLoad) Do(args []string, commandEnv *CommandEnv, writer io.
 		var wg sync.WaitGroup
 
 		for {
-			if n, err := io.ReadFull(dst, sizeBuf); n != 4 {
+			if _, err := io.ReadFull(dst, sizeBuf); err != nil {
 				if err == io.EOF {
 					return nil
 				}
@@ -108,7 +108,7 @@ func (c *commandFsMetaLoad) Do(args []string, commandEnv *CommandEnv, writer io.
 
 			data := make([]byte, int(size))
 
-			if n, err := io.ReadFull(dst, data); n != len(data) {
+			if _, err := io.ReadFull(dst, data); err != nil {
 				return err
 			}
 

--- a/weed/shell/command_fs_meta_load.go
+++ b/weed/shell/command_fs_meta_load.go
@@ -97,7 +97,7 @@ func (c *commandFsMetaLoad) Do(args []string, commandEnv *CommandEnv, writer io.
 		var wg sync.WaitGroup
 
 		for {
-			if n, err := dst.Read(sizeBuf); n != 4 {
+			if n, err := io.ReadFull(dst, sizeBuf); n != 4 {
 				if err == io.EOF {
 					return nil
 				}
@@ -108,7 +108,7 @@ func (c *commandFsMetaLoad) Do(args []string, commandEnv *CommandEnv, writer io.
 
 			data := make([]byte, int(size))
 
-			if n, err := dst.Read(data); n != len(data) {
+			if n, err := io.ReadFull(dst, data); n != len(data) {
 				return err
 			}
 


### PR DESCRIPTION
# What problem are we solving?

io.Reader may read less bytes than the buffer length without error, this is rare if reading from disk but quite possible if reading from compressed stream or from network. We should use ReadFull here.

# How are we solving the problem?



# How is the PR tested?



# Checks
- [ ] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.
