### PR TITLE
fix subscribe stuck

### DIFF
--- a/weed/filer/meta_aggregator.go
+++ b/weed/filer/meta_aggregator.go
@@ -3,8 +3,6 @@ package filer
 import (
 	"context"
 	"fmt"
-	"github.com/seaweedfs/seaweedfs/weed/pb/master_pb"
-	"github.com/seaweedfs/seaweedfs/weed/util"
 	"io"
 	"strings"
 	"sync"
@@ -17,6 +15,8 @@ import (
 	"github.com/seaweedfs/seaweedfs/weed/glog"
 	"github.com/seaweedfs/seaweedfs/weed/pb"
 	"github.com/seaweedfs/seaweedfs/weed/pb/filer_pb"
+	"github.com/seaweedfs/seaweedfs/weed/pb/master_pb"
+	"github.com/seaweedfs/seaweedfs/weed/util"
 	"github.com/seaweedfs/seaweedfs/weed/util/log_buffer"
 )
 
@@ -29,7 +29,6 @@ type MetaAggregator struct {
 	peerChans      map[pb.ServerAddress]chan struct{}
 	peerChansLock  sync.Mutex
 	// notifying clients
-	ListenersLock sync.Mutex
 	ListenersCond *sync.Cond
 }
 
@@ -42,10 +41,10 @@ func NewMetaAggregator(filer *Filer, self pb.ServerAddress, grpcDialOption grpc.
 		grpcDialOption: grpcDialOption,
 		peerChans:      make(map[pb.ServerAddress]chan struct{}),
 	}
-	t.ListenersCond = sync.NewCond(&t.ListenersLock)
 	t.MetaLogBuffer = log_buffer.NewLogBuffer("aggr", LogFlushInterval, nil, nil, func() {
 		t.ListenersCond.Broadcast()
 	})
+	t.ListenersCond = sync.NewCond(&t.MetaLogBuffer.RWMutex)
 	return t
 }
 

--- a/weed/mq/topic/local_partition.go
+++ b/weed/mq/topic/local_partition.go
@@ -3,6 +3,10 @@ package topic
 import (
 	"context"
 	"fmt"
+	"sync"
+	"sync/atomic"
+	"time"
+
 	"github.com/seaweedfs/seaweedfs/weed/glog"
 	"github.com/seaweedfs/seaweedfs/weed/pb"
 	"github.com/seaweedfs/seaweedfs/weed/pb/mq_pb"
@@ -10,9 +14,6 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
-	"sync"
-	"sync/atomic"
-	"time"
 )
 
 type LocalPartition struct {
@@ -20,7 +21,6 @@ type LocalPartition struct {
 	AckTsNs        int64
 
 	// notifying clients
-	ListenersLock sync.Mutex
 	ListenersCond *sync.Cond
 
 	Partition
@@ -41,13 +41,14 @@ func NewLocalPartition(partition Partition, logFlushFn log_buffer.LogFlushFuncTy
 		Publishers:  NewLocalPartitionPublishers(),
 		Subscribers: NewLocalPartitionSubscribers(),
 	}
-	lp.ListenersCond = sync.NewCond(&lp.ListenersLock)
+
 	lp.LogBuffer = log_buffer.NewLogBuffer(fmt.Sprintf("%d/%04d-%04d", partition.UnixTimeNs, partition.RangeStart, partition.RangeStop),
 		2*time.Minute, logFlushFn, readFromDiskFn, func() {
 			if atomic.LoadInt64(&lp.ListenersWaits) > 0 {
 				lp.ListenersCond.Broadcast()
 			}
 		})
+	lp.ListenersCond = sync.NewCond(&lp.LogBuffer.RWMutex)
 	return lp
 }
 

--- a/weed/server/filer_grpc_server_sub_meta.go
+++ b/weed/server/filer_grpc_server_sub_meta.go
@@ -81,9 +81,7 @@ func (fs *FilerServer) SubscribeMetadata(req *filer_pb.SubscribeMetadataRequest,
 		glog.V(4).Infof("read in memory %v aggregated subscribe %s from %+v", clientName, req.PathPrefix, lastReadTime)
 
 		lastReadTime, isDone, readInMemoryLogErr = fs.filer.MetaAggregator.MetaLogBuffer.LoopProcessLogData("aggMeta:"+clientName, lastReadTime, req.UntilNs, func() bool {
-			fs.filer.MetaAggregator.ListenersLock.Lock()
 			fs.filer.MetaAggregator.ListenersCond.Wait()
-			fs.filer.MetaAggregator.ListenersLock.Unlock()
 			return fs.hasClient(req.ClientId, req.ClientEpoch)
 		}, eachLogEntryFn)
 		if readInMemoryLogErr != nil {
@@ -165,11 +163,9 @@ func (fs *FilerServer) SubscribeLocalMetadata(req *filer_pb.SubscribeMetadataReq
 		glog.V(0).Infof("read in memory %v local subscribe %s from %+v", clientName, req.PathPrefix, lastReadTime)
 
 		lastReadTime, isDone, readInMemoryLogErr = fs.filer.LocalMetaLogBuffer.LoopProcessLogData("localMeta:"+clientName, lastReadTime, req.UntilNs, func() bool {
-			fs.listenersLock.Lock()
 			atomic.AddInt64(&fs.listenersWaits, 1)
 			fs.listenersCond.Wait()
 			atomic.AddInt64(&fs.listenersWaits, -1)
-			fs.listenersLock.Unlock()
 			if !fs.hasClient(req.ClientId, req.ClientEpoch) {
 				return false
 			}

--- a/weed/server/filer_server.go
+++ b/weed/server/filer_server.go
@@ -83,7 +83,6 @@ type FilerServer struct {
 	listenersWaits   int64
 
 	// notifying clients
-	listenersLock sync.Mutex
 	listenersCond *sync.Cond
 
 	inFlightDataLimitCond *sync.Cond
@@ -145,7 +144,6 @@ func NewFilerServer(defaultMux, readonlyMux *http.ServeMux, option *FilerOption)
 		knownListeners:        make(map[int32]int32),
 		inFlightDataLimitCond: sync.NewCond(new(sync.Mutex)),
 	}
-	fs.listenersCond = sync.NewCond(&fs.listenersLock)
 
 	option.Masters.RefreshBySrvIfAvailable()
 	if len(option.Masters.GetInstances()) == 0 {
@@ -173,6 +171,7 @@ func NewFilerServer(defaultMux, readonlyMux *http.ServeMux, option *FilerOption)
 			fs.listenersCond.Broadcast()
 		}
 	})
+	fs.listenersCond = sync.NewCond(&fs.filer.LocalMetaLogBuffer.RWMutex)
 	fs.filer.Cipher = option.Cipher
 	// we do not support IP whitelist right now
 	fs.filerGuard = security.NewGuard([]string{}, signingKey, expiresAfterSec, readSigningKey, readExpiresAfterSec)

--- a/weed/util/log_buffer/log_buffer.go
+++ b/weed/util/log_buffer/log_buffer.go
@@ -229,7 +229,7 @@ func (d *dataToFlush) releaseMemory() {
 	bufferPool.Put(d.data)
 }
 
-func (logBuffer *LogBuffer) ReadFromBuffer(lastReadPosition MessagePosition) (bufferCopy *bytes.Buffer, batchIndex int64, err error) {
+func (logBuffer *LogBuffer) ReadFromBuffer(lastReadPosition MessagePosition) (bufferCopy *bytes.Buffer, batchIndex, LastTsNs int64, err error) {
 	logBuffer.RLock()
 	defer logBuffer.RUnlock()
 
@@ -256,39 +256,37 @@ func (logBuffer *LogBuffer) ReadFromBuffer(lastReadPosition MessagePosition) (bu
 	}
 	if tsMemory.IsZero() { // case 2.2
 		// println("2.2 no data")
-		return nil, -2, nil
+		return nil, -2, logBuffer.LastTsNs, nil
 	} else if lastReadPosition.Before(tsMemory) && lastReadPosition.BatchIndex+1 < tsBatchIndex { // case 2.3
 		if !logBuffer.lastFlushDataTime.IsZero() {
 			glog.V(0).Infof("resume with last flush time: %v", logBuffer.lastFlushDataTime)
-			return nil, -2, ResumeFromDiskError
+			return nil, -2, logBuffer.LastTsNs, ResumeFromDiskError
 		}
 	}
 
 	// the following is case 2.1
 
-	if lastReadPosition.Equal(logBuffer.stopTime) {
-		return nil, logBuffer.batchIndex, nil
-	}
-	if lastReadPosition.After(logBuffer.stopTime) {
-		// glog.Fatalf("unexpected last read time %v, older than latest %v", lastReadPosition, m.stopTime)
-		return nil, logBuffer.batchIndex, nil
-	}
-	if lastReadPosition.Before(logBuffer.startTime) {
-		// println("checking ", lastReadPosition.UnixNano())
-		for _, buf := range logBuffer.prevBuffers.buffers {
-			if buf.startTime.After(lastReadPosition.Time) {
-				// glog.V(4).Infof("%s return the %d sealed buffer %v", m.name, i, buf.startTime)
-				// println("return the", i, "th in memory", buf.startTime.UnixNano())
-				return copiedBytes(buf.buf[:buf.size]), buf.batchIndex, nil
-			}
-			if !buf.startTime.After(lastReadPosition.Time) && buf.stopTime.After(lastReadPosition.Time) {
-				pos := buf.locateByTs(lastReadPosition.Time)
-				// fmt.Printf("locate buffer[%d] pos %d\n", i, pos)
-				return copiedBytes(buf.buf[pos:buf.size]), buf.batchIndex, nil
+	// Check prevBuffers first because current buffer may have been flushed
+	// When buffer is flushed, stopTime and startTime is reset to 0, but prevBuffers still has data
+	for _, buf := range logBuffer.prevBuffers.buffers {
+		if buf.stopTime.After(lastReadPosition.Time) {
+			// Found buffer with data after lastReadPosition
+			pos := buf.locateByTs(lastReadPosition.Time)
+			if pos < buf.size {
+				return copiedBytes(buf.buf[pos:buf.size]), buf.batchIndex, logBuffer.LastTsNs, nil
 			}
 		}
-		// glog.V(4).Infof("%s return the current buf %v", m.name, lastReadPosition)
-		return copiedBytes(logBuffer.buf[:logBuffer.pos]), logBuffer.batchIndex, nil
+	}
+
+	// No more data in prevBuffers, check if we've reached the end of current buffer
+	// If lastReadPosition >= stopTime, it means we've processed all events up to stopTime
+	if !lastReadPosition.Before(logBuffer.stopTime) {
+		return nil, logBuffer.batchIndex, logBuffer.LastTsNs, nil
+	}
+
+	if lastReadPosition.Before(logBuffer.startTime) {
+		// println("checking ", lastReadPosition.UnixNano())
+		return copiedBytes(logBuffer.buf[:logBuffer.pos]), logBuffer.batchIndex, logBuffer.LastTsNs, nil
 	}
 
 	lastTs := lastReadPosition.UnixNano()
@@ -321,7 +319,7 @@ func (logBuffer *LogBuffer) ReadFromBuffer(lastReadPosition MessagePosition) (bu
 			}
 			if prevT <= lastTs {
 				// fmt.Printf("found l=%d, m-1=%d(ts=%d), m=%d(ts=%d), h=%d [%d, %d) \n", l, mid-1, prevT, mid, t, h, pos, m.pos)
-				return copiedBytes(logBuffer.buf[pos:logBuffer.pos]), logBuffer.batchIndex, nil
+				return copiedBytes(logBuffer.buf[pos:logBuffer.pos]), logBuffer.batchIndex, logBuffer.LastTsNs, nil
 			}
 			h = mid
 		}
@@ -330,9 +328,9 @@ func (logBuffer *LogBuffer) ReadFromBuffer(lastReadPosition MessagePosition) (bu
 
 	// FIXME: this could be that the buffer has been flushed already
 	println("Not sure why no data", lastReadPosition.BatchIndex, tsBatchIndex)
-	return nil, -2, nil
-
+	return nil, -2, logBuffer.LastTsNs, nil
 }
+
 func (logBuffer *LogBuffer) ReleaseMemory(b *bytes.Buffer) {
 	bufferPool.Put(b)
 }

--- a/weed/util/log_buffer/log_read.go
+++ b/weed/util/log_buffer/log_read.go
@@ -34,6 +34,7 @@ func (logBuffer *LogBuffer) LoopProcessLogData(readerName string, startPosition 
 	// loop through all messages
 	var bytesBuf *bytes.Buffer
 	var batchIndex int64
+	var lastTsNs int64
 	lastReadPosition = startPosition
 	var entryCounter int64
 	defer func() {
@@ -48,7 +49,7 @@ func (logBuffer *LogBuffer) LoopProcessLogData(readerName string, startPosition 
 		if bytesBuf != nil {
 			logBuffer.ReleaseMemory(bytesBuf)
 		}
-		bytesBuf, batchIndex, err = logBuffer.ReadFromBuffer(lastReadPosition)
+		bytesBuf, batchIndex, lastTsNs, err = logBuffer.ReadFromBuffer(lastReadPosition)
 		if err == ResumeFromDiskError {
 			time.Sleep(1127 * time.Millisecond)
 			return lastReadPosition, isDone, ResumeFromDiskError
@@ -66,23 +67,17 @@ func (logBuffer *LogBuffer) LoopProcessLogData(readerName string, startPosition 
 				isDone = true
 				return
 			}
-			logBuffer.RLock()
-			lastTsNs := logBuffer.LastTsNs
-			logBuffer.RUnlock()
-			loopTsNs := lastTsNs // make a copy
 
-			for lastTsNs == loopTsNs {
-				if waitForDataFn() {
-					// Update loopTsNs and loop again
-					logBuffer.RLock()
-					loopTsNs = logBuffer.LastTsNs
-					logBuffer.RUnlock()
-					continue
-				} else {
+			logBuffer.Lock()
+			for lastTsNs == logBuffer.LastTsNs {
+				if !waitForDataFn() {
 					isDone = true
+					logBuffer.Unlock()
 					return
 				}
 			}
+			logBuffer.Unlock()
+
 			if logBuffer.IsStopping() {
 				isDone = true
 				return


### PR DESCRIPTION
# What problem are we solving?
在写一批文件的同时 Subscribe，如果文件写的快，但处理 Subscribe 的 event 逻辑比较慢，会出现 Subscribe 卡在某个 event 之后不继续推送新的 event。


# How are we solving the problem?
1. 修复 ReadFromBuffer 的逻辑漏洞。因为 logBuffer 有可能被 flush，stopTime 会被 reset 为0，ReadFromBuffer 会错误地判断没有新的 buffer 需要被 read，从而返回 nil，这时候会进入等待新的 lastTsNs 的 Wait() 中，但因为这一批文件已经写完, lastTsNs 不会再被更新，导致 Subscribe 被卡死。所以在判断 stopTime 之前，需要先检查是否存在 previous buffer。
2. 在发现 buffer == nil 之后再去读取 lastTsNs，这个值可能已经改变，这两个需要原子化处理
3. 修复了 sync.Cond 的使用错误。首先，wait 之前不用每次都 lock，wait 本身就隐含了unlock和lock。其次，wait 的 lock 和 lastTsNs 的 lock 需要用同一把锁


# How is the PR tested?



# Checks
- [ ] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.
