### PR TITLE
S3: add CRC combine and fix multipart checksum for manifest folding

### DIFF
--- a/weed/s3api/crc_combine.go
+++ b/weed/s3api/crc_combine.go
@@ -1,0 +1,226 @@
+package s3api
+
+import "math"
+
+// crcParams describes a CRC algorithm in the Rocksoft/Williams parameterization (see "15. A
+// Parameterized Model For CRC Algorithms" in http://www.ross.net/crc/download/crc_v3.txt)
+type crcParams struct {
+	width  uint32 // the width of the algorithm expressed in bits; 1 less than the width of poly
+	poly   uint64 // the unreflected poly
+	init   uint64 // initial register value
+	xorout uint64 // value XORed into the final register
+	refin  bool   // reflect input bytes
+	refout bool   // reflect final register
+}
+
+var crcCombineParams = map[ChecksumAlgorithm]crcParams{
+	ChecksumAlgorithmCRC64NVMe: {
+		width:  64,
+		poly:   0xad93d23594c93659,
+		init:   0xffffffffffffffff,
+		xorout: 0xffffffffffffffff,
+		refin:  true,
+		refout: true,
+	},
+	ChecksumAlgorithmCRC32: {
+		width:  32,
+		poly:   0x04c11db7,
+		init:   0xffffffff,
+		xorout: 0xffffffff,
+		refin:  true,
+		refout: true,
+	},
+	ChecksumAlgorithmCRC32C: {
+		width:  32,
+		poly:   0x1edc6f41,
+		init:   0xffffffff,
+		xorout: 0xffffffff,
+		refin:  true,
+		refout: true,
+	},
+}
+
+// Ported from: https://github.com/awesomized/crc-fast-rust/blob/3a853cc7daf2cd47cc4466f198680cabdfb0b5fa/src/combine.rs
+
+/*
+  Derived from this excellent answer by Mark Adler on StackOverflow:
+  https://stackoverflow.com/questions/29915764/generic-crc-8-16-32-64-combine-implementation/29928573#29928573
+*/
+
+/* crccomb.c -- generalized combination of CRCs
+ * Copyright (C) 2015 Mark Adler
+ * Version 1.1  29 Apr 2015  Mark Adler
+ */
+
+/*
+ This software is provided 'as-is', without any express or implied
+ warranty.  In no event will the author be held liable for any damages
+ arising from the use of this software.
+
+ Permission is granted to anyone to use this software for any purpose,
+ including commercial applications, and to alter it and redistribute it
+ freely, subject to the following restrictions:
+
+ 1. The origin of this software must not be misrepresented; you must not
+    claim that you wrote the original software. If you use this software
+    in a product, an acknowledgment in the product documentation would be
+    appreciated but is not required.
+ 2. Altered source versions must be plainly marked as such, and must not be
+    misrepresented as being the original software.
+ 3. This notice may not be removed or altered from any source distribution.
+
+ Mark Adler
+ madler@alumni.caltech.edu
+*/
+
+/*
+  zlib provides a fast operation to combine the CRCs of two sequences of bytes
+  into a single CRC, which is the CRC of the two sequences concatenated.  That
+  operation requires only the two CRC's and the length of the second sequence.
+  The routine in zlib only works on the particular CRC-32 used by zlib.  The
+  code provided here generalizes that operation to apply to a wide range of
+  CRCs.  The CRC is specified in a series of #defines, based on the
+  parameterization found in Ross Williams's excellent CRC tutorial here:
+
+     http://www.ross.net/crc/download/crc_v3.txt
+
+  A comprehensive catalogue of known CRCs, their parameters, check values, and
+  references can be found here:
+
+     http://reveng.sourceforge.net/crc-catalogue/all.htm
+*/
+
+// Multiply the GF(2) vector vec by the GF(2) matrix mat, returning the
+// resulting vector.  The vector is stored as bits in a crc_t.  The matrix is
+// similarly stored with each column as a crc_t, where the number of columns is
+// at least enough to cover the position of the most significant 1 bit in the
+// vector (so a dimension parameter is not needed).
+func gf2MatrixTimes(mat *[64]uint64, vec uint64) uint64 {
+	var sum uint64
+	idx := 0
+
+	for vec > 0 {
+		if vec&1 == 1 {
+			sum ^= mat[idx]
+		}
+		vec >>= 1
+		idx++
+	}
+
+	return sum
+}
+
+// Multiply the matrix mat by itself, returning the result in square.  WIDTH is
+// the dimension of the matrices, i.e., the number of bits in each crc_t
+// (rows), and the number of crc_t's (columns).
+func gf2MatrixSquare(square *[64]uint64, mat *[64]uint64) {
+	for n := 0; n < 64; n++ {
+		square[n] = gf2MatrixTimes(mat, mat[n])
+	}
+}
+
+// Combine the CRCs of two successive sequences, where crc1 is the CRC of the
+// first sequence of bytes, crc2 is the CRC of the immediately following
+// sequence of bytes, and len2 is the length of the second sequence.  The CRC
+// of the combined sequence is returned.
+func combineCRC(crc1 uint64, crc2 uint64, len2 uint64, params crcParams) uint64 {
+	even := [64]uint64{} /* even-power-of-two zeros operator */
+	odd := [64]uint64{}  /* odd-power-of-two zeros operator */
+
+	/* exclusive-or the result with len2 zeros applied to the CRC of an empty
+	   sequence */
+	crc1 ^= params.init ^ params.xorout
+
+	/* construct the operator for one zero bit and put in odd[] */
+	if params.refin && params.refout {
+		// use the reflected POLY
+		odd[0] = reflectPoly(params.poly, params.width)
+		col := uint64(1)
+		for n := uint32(1); n < params.width; n++ {
+			odd[n] = col
+			col <<= 1
+		}
+	} else if !params.refin && !params.refout {
+		col := uint64(2)
+		for n := uint32(0); n < params.width-1; n++ {
+			odd[n] = col
+			col <<= 1
+		}
+		odd[params.width-1] = params.poly
+	} else {
+		panic("Unsupported CRC configuration")
+	}
+
+	/* put operator for two zero bits in even */
+	gf2MatrixSquare(&even, &odd)
+
+	/* put operator for four zero bits in odd */
+	gf2MatrixSquare(&odd, &even)
+
+	/* apply len2 zeros to crc1 (first square will put the operator for one
+	   zero byte, eight zero bits, in even) */
+	for {
+		/* apply zeros operator for this bit of len2 */
+		gf2MatrixSquare(&even, &odd)
+		if len2&1 == 1 {
+			crc1 = gf2MatrixTimes(&even, crc1)
+		}
+		len2 >>= 1
+
+		/* if no more bits set, then done */
+		if len2 == 0 {
+			break
+		}
+
+		/* another iteration of the loop with odd and even swapped */
+		gf2MatrixSquare(&odd, &even)
+		if len2&1 == 1 {
+			crc1 = gf2MatrixTimes(&odd, crc1)
+		}
+		len2 >>= 1
+
+		/* if no more bits set, then done */
+		if len2 == 0 {
+			break
+		}
+	}
+
+	/* return combined crc */
+	return crc1 ^ crc2
+}
+
+func reflectPoly(poly uint64, width uint32) uint64 {
+	if width > 64 {
+		panic("Width must be <= 64 bits")
+	}
+
+	// First reverse all bits
+	reversed := bitReverse(poly)
+
+	// Shift right to get the significant bits in the correct position
+	// For a 32-bit poly, we need to shift right by (64 - 32) = 32 bits
+	shifted := reversed >> (64 - width)
+
+	// Create mask for the target width
+	var mask uint64
+	if width == 64 {
+		mask = math.MaxUint64
+	} else {
+		mask = (1 << width) - 1
+	}
+
+	// Apply mask to ensure we only keep the bits we want
+	return shifted & mask
+}
+
+func bitReverse(forward uint64) uint64 {
+	reversed := uint64(0)
+
+	for i := 0; i < 64; i++ {
+		reversed <<= 1
+		reversed |= forward & 1
+		forward >>= 1
+	}
+
+	return reversed
+}

--- a/weed/s3api/filer_multipart.go
+++ b/weed/s3api/filer_multipart.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/seaweedfs/seaweedfs/weed/s3api/s3_constants"
 	"github.com/seaweedfs/seaweedfs/weed/stats"
+	"github.com/seaweedfs/seaweedfs/weed/util"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/s3"
@@ -514,9 +515,12 @@ func (s3a *S3ApiServer) prepareMultipartCompletionState(r *http.Request, input *
 		}
 	}
 
-	// Compute composite checksum from per-part checksums if the upload
-	// was initiated with a checksum algorithm (stored in upload dir entry)
+	// Compute the object checksum from per-part checksums if the upload was
+	// initiated with a checksum algorithm (stored in the upload dir entry).
+	// The checksum type (COMPOSITE or FULL_OBJECT) is resolved from the
+	// x-amz-checksum-type header captured at CreateMultipartUpload
 	checksumHeaderName := ""
+	checksumType := ""
 	checksumValue := ""
 	if pentry.Extended != nil {
 		if algoName, ok := pentry.Extended[s3_constants.ExtChecksumAlgorithm]; ok {
@@ -524,10 +528,26 @@ func (s3a *S3ApiServer) prepareMultipartCompletionState(r *http.Request, input *
 		}
 	}
 	if checksumHeaderName != "" {
+		algo := checksumAlgorithmFromHeaderName(checksumHeaderName)
+		requestedType := ""
+		if pentry.Extended != nil {
+			requestedType = string(pentry.Extended[s3_constants.ExtChecksumType])
+		}
+		resolvedType, typeErr := resolveMultipartChecksumType(algo, requestedType)
+		if typeErr != nil {
+			glog.Errorf("completeMultipartUpload: %v", typeErr)
+			return nil, nil, s3err.ErrInvalidRequest
+		}
+		checksumType = resolvedType
+
 		var checksumErr error
-		checksumValue, checksumErr = computeCompositeChecksum(checksumHeaderName, partEntries, completedPartNumbers)
+		if checksumType == s3_constants.ChecksumTypeFullObject {
+			checksumValue, checksumErr = computeFullObjectChecksum(checksumHeaderName, partEntries, completedPartNumbers)
+		} else {
+			checksumValue, checksumErr = computeCompositeChecksum(checksumHeaderName, partEntries, completedPartNumbers)
+		}
 		if checksumErr != nil {
-			glog.Errorf("completeMultipartUpload: composite checksum computation failed: %v", checksumErr)
+			glog.Errorf("completeMultipartUpload: %s checksum computation failed: %v", checksumType, checksumErr)
 			return nil, nil, s3err.ErrInvalidPart
 		}
 	}
@@ -1345,6 +1365,82 @@ func computeCompositeChecksum(checksumHeaderName string, partEntries map[int][]*
 	return fmt.Sprintf("%s-%d", base64.StdEncoding.EncodeToString(compositeRaw), len(completedPartNumbers)), nil
 }
 
+// decodePartChecksum decodes the stored checksum for a part, validating the algorithm matches.
+func decodePartChecksum(partNumber int, entries []*filer_pb.Entry, checksumHeaderName string) ([]byte, *filer_pb.Entry, error) {
+	if len(entries) == 0 {
+		return nil, nil, fmt.Errorf("part %d not found", partNumber)
+	}
+	if len(entries) > 1 {
+		sortEntriesByLatestChunk(entries)
+	}
+	entry := entries[0]
+	if entry.Extended == nil {
+		return nil, nil, fmt.Errorf("part %d missing checksum: upload initiated with %s but part was uploaded without a checksum", partNumber, checksumHeaderName)
+	}
+	// Validate the part's checksum algorithm matches the upload's expected algorithm
+	partAlgo, ok := entry.Extended[s3_constants.ExtChecksumAlgorithm]
+	if !ok || len(partAlgo) == 0 {
+		return nil, nil, fmt.Errorf("part %d missing checksum: upload initiated with %s but part was uploaded without a checksum", partNumber, checksumHeaderName)
+	}
+	if string(partAlgo) != checksumHeaderName {
+		return nil, nil, fmt.Errorf("part %d checksum algorithm mismatch: upload expects %s but part has %s", partNumber, checksumHeaderName, string(partAlgo))
+	}
+	partChecksumB64, ok := entry.Extended[s3_constants.ExtChecksumValue]
+	if !ok || len(partChecksumB64) == 0 {
+		return nil, nil, fmt.Errorf("part %d missing checksum value: upload initiated with %s but part has no checksum value", partNumber, checksumHeaderName)
+	}
+	raw, err := base64.StdEncoding.DecodeString(string(partChecksumB64))
+	if err != nil {
+		return nil, nil, fmt.Errorf("part %d has invalid checksum encoding: %w", partNumber, err)
+	}
+	return raw, entry, nil
+}
+
+// computeFullObjectChecksum computes a FULL_OBJECT checksum from per-part checksums
+// by combining the per-part CRCs into the CRC of the whole object. The result is the
+// base64-encoded whole-object checksum with NO "-N" suffix (a full-object checksum
+// is indistinguishable from a single-part upload's checksum). This is required for
+// CRC64NVME, which AWS only supports as a full-object checksum.
+func computeFullObjectChecksum(checksumHeaderName string, partEntries map[int][]*filer_pb.Entry, completedPartNumbers []int) (string, error) {
+	algo := checksumAlgorithmFromHeaderName(checksumHeaderName)
+	params, ok := crcCombineParams[algo]
+	if !ok {
+		return "", fmt.Errorf("full object checksum not supported for %s", checksumHeaderName)
+	}
+
+	checksumBytes := int(params.width / 8)
+
+	var combined uint64
+	for i, partNumber := range completedPartNumbers {
+		raw, entry, err := decodePartChecksum(partNumber, partEntries[partNumber], checksumHeaderName)
+		if err != nil {
+			return "", err
+		}
+		if len(raw) != checksumBytes {
+			return "", fmt.Errorf("part %d checksum has unexpected length %d for %s", partNumber, len(raw), checksumHeaderName)
+		}
+
+		crc := util.BytesToUint64(raw)
+
+		if i == 0 {
+			combined = crc
+		} else {
+			partLen := filer.FileSize(entry)
+			combined = combineCRC(combined, crc, partLen, params)
+		}
+	}
+
+	// Write the low checksumBytes bytes of the combined CRC big-endian. We can't
+	// use util.Uint64toBytes here because it unconditionally writes 8 bytes, which
+	// would panic for narrower CRCs (e.g. 4-byte CRC32/CRC32C).
+	out := make([]byte, checksumBytes)
+	for i := 0; i < checksumBytes; i++ {
+		out[checksumBytes-1-i] = byte(combined >> (i * 8))
+	}
+
+	return base64.StdEncoding.EncodeToString(out), nil
+}
+
 // checksumAlgorithmFromHeaderName maps a canonical header name back to its algorithm.
 func checksumAlgorithmFromHeaderName(headerName string) ChecksumAlgorithm {
 	for _, entry := range checksumHeaders {
@@ -1399,4 +1495,44 @@ func validateCompletePartETag(partETag string, entry *filer_pb.Entry) (match boo
 	}
 
 	return normalizedPartETag == normalizedEntryETag, false, normalizedPartETag, normalizedEntryETag
+}
+
+type checksumTypeSupport struct {
+	composite  bool
+	fullObject bool
+}
+
+var checksumTypeSupportByAlgo = map[ChecksumAlgorithm]checksumTypeSupport{
+	ChecksumAlgorithmCRC32:     {composite: true, fullObject: true},
+	ChecksumAlgorithmCRC32C:    {composite: true, fullObject: true},
+	ChecksumAlgorithmCRC64NVMe: {fullObject: true},
+	ChecksumAlgorithmSHA1:       {composite: true}, // Technically, fullObject could be supported, but is not yet implemented
+	ChecksumAlgorithmSHA256:     {composite: true}, // Technically, fullObject could be supported, but is not yet implemented
+}
+
+func resolveMultipartChecksumType(algo ChecksumAlgorithm, requested string) (string, error) {
+	support, ok := checksumTypeSupportByAlgo[algo]
+	if !ok {
+		return "", fmt.Errorf("unsupported checksum algorithm %v", algo)
+	}
+
+	switch strings.ToUpper(strings.TrimSpace(requested)) {
+	case "":
+		if support.composite {
+			return s3_constants.ChecksumTypeComposite, nil
+		}
+		return s3_constants.ChecksumTypeFullObject, nil
+	case s3_constants.ChecksumTypeComposite:
+		if !support.composite {
+			return "", fmt.Errorf("checksum algorithm %v does not support %s checksums", algo, s3_constants.ChecksumTypeComposite)
+		}
+		return s3_constants.ChecksumTypeComposite, nil
+	case s3_constants.ChecksumTypeFullObject:
+		if !support.fullObject {
+			return "", fmt.Errorf("checksum algorithm %v does not support %s checksums", algo, s3_constants.ChecksumTypeFullObject)
+		}
+		return s3_constants.ChecksumTypeFullObject, nil
+	default:
+		return "", fmt.Errorf("invalid checksum type %q", requested)
+	}
 }

--- a/weed/s3api/s3_constants/extend_key.go
+++ b/weed/s3api/s3_constants/extend_key.go
@@ -36,6 +36,7 @@ const (
 	// S3 checksum storage keys (use x-seaweedfs- prefix to avoid leaking in generic header loop)
 	ExtChecksumAlgorithm = "x-seaweedfs-checksum-algorithm"
 	ExtChecksumValue     = "x-seaweedfs-checksum-value"
+	ExtChecksumType      = "x-seaweedfs-checksum-type"
 
 	// Bucket Policy
 	ExtBucketPolicyKey = "Seaweed-X-Amz-Bucket-Policy"
@@ -50,6 +51,10 @@ const (
 	ExtObjectLockDefaultModeKey  = "Lock-Default-Mode"
 	ExtObjectLockDefaultDaysKey  = "Lock-Default-Days"
 	ExtObjectLockDefaultYearsKey = "Lock-Default-Years"
+
+	// Checksum types
+	ChecksumTypeComposite  = "COMPOSITE"
+	ChecksumTypeFullObject = "FULL_OBJECT"
 )
 
 // Object Lock and Retention Constants

--- a/weed/s3api/s3_constants/header.go
+++ b/weed/s3api/s3_constants/header.go
@@ -86,6 +86,7 @@ const (
 	AmzChecksumSHA256       = "X-Amz-Checksum-Sha256"
 	AmzTrailer              = "X-Amz-Trailer"
 	AmzSdkChecksumAlgorithm = "X-Amz-Sdk-Checksum-Algorithm"
+	AmzChecksumType         = "X-Amz-Checksum-Type"
 
 	// S3 conditional headers
 	IfMatch           = "If-Match"


### PR DESCRIPTION

# What problem are we solving?
之前的pick有一些checksum相关的函数依赖没有一起，导致build失败


# How are we solving the problem?
- Add CRC combine functions for full-object checksum computation (crc_combine.go)
- Fix checksumType variable definition in prepareMultipartCompletionState
- Support both COMPOSITE and FULL_OBJECT checksum types for multipart uploads
- Required for CRC64NVME full-object checksum support

# How is the PR tested?



# Checks
- [ ] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.
- [ ] All AI code review comments have been addressed. No more comments to fix if reviewed again. Reviewer may request additional gemini and copilot reviews.

# Checks for AI generated PRs
- [ ] I have reviewed every line of code.
- [ ] The PR is kept as minimum as possible. Large PRs would not be accepted.
