### PR TITLE
volume: recover .idx rows overwritten by tiered deletes (#10474)

### DIFF
--- a/weed/storage/volume_idx_repair.go
+++ b/weed/storage/volume_idx_repair.go
@@ -1,0 +1,228 @@
+package storage
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/seaweedfs/seaweedfs/weed/glog"
+	"github.com/seaweedfs/seaweedfs/weed/storage/backend"
+	"github.com/seaweedfs/seaweedfs/weed/storage/idx"
+	"github.com/seaweedfs/seaweedfs/weed/storage/needle"
+	"github.com/seaweedfs/seaweedfs/weed/storage/needle_map"
+	"github.com/seaweedfs/seaweedfs/weed/storage/super_block"
+	"github.com/seaweedfs/seaweedfs/weed/storage/types"
+)
+
+// errStopIdxWalk ends an idx.WalkIndexFile early once the answer is known.
+var errStopIdxWalk = errors.New("stop idx walk")
+
+// repairIdxHeadTombstones restores the .idx rows that deletes on a tiered
+// read-only volume used to overwrite.
+//
+// The sorted-file needle map opened .idx read-write but never seeded its write
+// position, so a delete wrote its (key, offset 0, tombstone) row at .idx offset
+// 0 and advanced one row at a time instead of appending. Every delete therefore
+// replaced one more row at the front of .idx, and the rows it replaced -- the
+// Put rows indexing the first needles in .dat -- were lost. Reads for those
+// needles return not-found even though .dat still holds them intact.
+//
+// The damage leaves a fingerprint: .idx begins with a run of offset-0
+// tombstones. A healthy .idx never does. Its first row is the Put for the first
+// needle in .dat, and an offset-0 tombstone -- a delete against a tiered volume,
+// which appends no .dat record and so has no extent to point at -- can only ever
+// land at the tail.
+//
+// .idx and .dat grow in lockstep, so the clobbered rows indexed exactly the
+// first N records of .dat. Re-deriving them is a header-only walk over the head
+// of .dat, which stays cheap even when .dat is served from a remote tier.
+//
+// The recovered rows go back in front, where the rows they replace used to sit,
+// and every existing row keeps its relative order behind them. That restores
+// .idx to .dat append order, which several readers lean on: the fingerprint is
+// gone so a later load stops after one row, the last row is the .dat-tail needle
+// again so CheckVolumeDataIntegrity keeps its O(1) path, and
+// BinarySearchByAppendAtNs sees ascending append timestamps.
+func (v *Volume) repairIdxHeadTombstones() (restored int, err error) {
+	if v.DataBackend == nil {
+		return 0, nil
+	}
+	version := v.Version()
+	firstNeedleOffset := int64(v.SuperBlock.BlockSize())
+	idxFileName := v.FileName(".idx")
+
+	clobbered, err := idxHeadTombstoneCount(idxFileName)
+	if err != nil || clobbered == 0 {
+		return 0, err
+	}
+
+	glog.V(0).Infof("volume %d: %s starts with %d offset-0 tombstones, recovering the .idx rows they overwrote from %s",
+		v.Id, idxFileName, clobbered, v.FileName(".dat"))
+
+	lost, order, err := scanDatHead(v.DataBackend, version, firstNeedleOffset, clobbered)
+	if err != nil {
+		return 0, err
+	}
+	if err = dropIndexedKeys(idxFileName, lost); err != nil {
+		return 0, err
+	}
+	if len(lost) == 0 {
+		return 0, nil
+	}
+
+	var rows []byte
+	for _, key := range order {
+		nv, ok := lost[key]
+		if !ok {
+			continue
+		}
+		rows = append(rows, nv.ToBytes()...)
+		restored++
+	}
+	return restored, prependIdxRows(idxFileName, rows)
+}
+
+// idxHeadTombstoneCount reports how many rows at the front of .idx are offset-0
+// tombstones. A healthy .idx answers 0 on its first row.
+func idxHeadTombstoneCount(idxFileName string) (clobbered int, err error) {
+	idxFile, err := os.Open(idxFileName)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return 0, nil
+		}
+		return 0, err
+	}
+	defer idxFile.Close()
+
+	err = idx.WalkIndexFile(idxFile, 0, func(_ types.NeedleId, offset types.Offset, size types.Size) error {
+		if !offset.IsZero() || !size.IsDeleted() {
+			return errStopIdxWalk
+		}
+		clobbered++
+		return nil
+	})
+	if errors.Is(err, errStopIdxWalk) {
+		err = nil
+	}
+	return clobbered, err
+}
+
+// scanDatHead reads the headers of the first limit records of .dat and returns
+// the needles they hold, in .dat order. A record with an invalid size is a
+// delete marker, so the key it names drops out of the result rather than being
+// resurrected.
+func scanDatHead(datBackend backend.BackendStorageFile, version needle.Version, firstNeedleOffset int64, limit int) (map[types.NeedleId]needle_map.NeedleValue, []types.NeedleId, error) {
+	scanner := &datHeadScanner{
+		limit: limit,
+		found: make(map[types.NeedleId]needle_map.NeedleValue),
+	}
+	if err := ScanVolumeFileFrom(version, datBackend, firstNeedleOffset, scanner); err != nil {
+		return nil, nil, fmt.Errorf("scan head of %s: %w", datBackend.Name(), err)
+	}
+	return scanner.found, scanner.order, nil
+}
+
+type datHeadScanner struct {
+	limit   int
+	visited int
+	found   map[types.NeedleId]needle_map.NeedleValue
+	order   []types.NeedleId
+}
+
+func (s *datHeadScanner) VisitSuperBlock(super_block.SuperBlock) error { return nil }
+
+func (s *datHeadScanner) ReadNeedleBody() bool { return false }
+
+func (s *datHeadScanner) VisitNeedle(n *needle.Needle, offset int64, _, _ []byte) error {
+	if n.Size.IsValid() {
+		if _, seen := s.found[n.Id]; !seen {
+			s.order = append(s.order, n.Id)
+		}
+		s.found[n.Id] = needle_map.NeedleValue{Key: n.Id, Offset: types.ToOffset(offset), Size: n.Size}
+	} else {
+		delete(s.found, n.Id)
+	}
+	s.visited++
+	if s.visited >= s.limit {
+		return io.EOF
+	}
+	return nil
+}
+
+// dropIndexedKeys removes every candidate the .idx already names, whether by a
+// Put row or a tombstone. What is left is only what the clobbered rows held.
+func dropIndexedKeys(idxFileName string, candidates map[types.NeedleId]needle_map.NeedleValue) error {
+	if len(candidates) == 0 {
+		return nil
+	}
+	idxFile, err := os.Open(idxFileName)
+	if err != nil {
+		return err
+	}
+	defer idxFile.Close()
+
+	err = idx.WalkIndexFile(idxFile, 0, func(key types.NeedleId, _ types.Offset, _ types.Size) error {
+		delete(candidates, key)
+		if len(candidates) == 0 {
+			return errStopIdxWalk
+		}
+		return nil
+	})
+	if errors.Is(err, errStopIdxWalk) {
+		err = nil
+	}
+	return err
+}
+
+// prependIdxRows rewrites .idx as rows followed by its current contents,
+// through a temp file and a rename so a crash mid-write never leaves a partial
+// index at the live name.
+func prependIdxRows(idxFileName string, rows []byte) error {
+	src, err := os.Open(idxFileName)
+	if err != nil {
+		return err
+	}
+	defer src.Close()
+
+	srcStat, err := src.Stat()
+	if err != nil {
+		return err
+	}
+
+	tmpFileName := idxFileName + ".tmp"
+	dst, err := os.OpenFile(tmpFileName, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, srcStat.Mode().Perm())
+	if err != nil {
+		return err
+	}
+	committed := false
+	defer func() {
+		dst.Close()
+		if !committed {
+			os.Remove(tmpFileName)
+		}
+	}()
+
+	// The rename replaces .idx with this file, so it has to carry the mode the
+	// index already had -- O_CREATE alone leaves it at the umask's mercy.
+	if err = dst.Chmod(srcStat.Mode().Perm()); err != nil {
+		return err
+	}
+	if _, err = dst.Write(rows); err != nil {
+		return err
+	}
+	if _, err = io.Copy(dst, src); err != nil {
+		return err
+	}
+	if err = dst.Sync(); err != nil {
+		return err
+	}
+	if err = dst.Close(); err != nil {
+		return err
+	}
+	if err = os.Rename(tmpFileName, idxFileName); err != nil {
+		return err
+	}
+	committed = true
+	return nil
+}

--- a/weed/storage/volume_idx_repair_test.go
+++ b/weed/storage/volume_idx_repair_test.go
@@ -1,0 +1,277 @@
+package storage
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/seaweedfs/seaweedfs/weed/pb/volume_server_pb"
+	"github.com/seaweedfs/seaweedfs/weed/storage/needle"
+	"github.com/seaweedfs/seaweedfs/weed/storage/needle_map"
+	"github.com/seaweedfs/seaweedfs/weed/storage/super_block"
+	"github.com/seaweedfs/seaweedfs/weed/storage/types"
+	"github.com/seaweedfs/seaweedfs/weed/storage/volume_info"
+)
+
+// clobberIdxHead reproduces the damage a delete on a tiered read-only volume
+// used to do: it writes (key, offset 0, tombstone) rows over the front of .idx
+// instead of appending them.
+func clobberIdxHead(t *testing.T, idxPath string, keys []uint64) {
+	t.Helper()
+	f, err := os.OpenFile(idxPath, os.O_WRONLY, 0644)
+	if err != nil {
+		t.Fatalf("open idx: %v", err)
+	}
+	defer f.Close()
+	for i, key := range keys {
+		row := needle_map.ToBytes(types.Uint64ToNeedleId(key), types.Offset{}, types.TombstoneFileSize)
+		if _, err := f.WriteAt(row, int64(i*types.NeedleMapEntrySize)); err != nil {
+			t.Fatalf("clobber row %d: %v", i, err)
+		}
+	}
+}
+
+func writeTestVolume(t *testing.T, dir string, needleCount int) map[uint64]*needle.Needle {
+	t.Helper()
+	v, err := NewVolume(dir, dir, "", 1, NeedleMapInMemory, &super_block.ReplicaPlacement{}, &needle.TTL{}, 0, 0, 0)
+	if err != nil {
+		t.Fatalf("volume creation: %v", err)
+	}
+	written := make(map[uint64]*needle.Needle)
+	for i := 1; i <= needleCount; i++ {
+		n := newRandomNeedle(uint64(i))
+		if _, _, _, err := v.writeNeedle2(n, true, false); err != nil {
+			v.Close()
+			t.Fatalf("write needle %d: %v", i, err)
+		}
+		written[uint64(i)] = n
+	}
+	v.Close()
+	return written
+}
+
+// loadVolumeWithoutWorker loads a volume without the background compaction worker.
+func loadVolumeWithoutWorker(dir, dirIdx, collection string, id int, needleMapKind NeedleMapKind, ldbTimeout int64) (*Volume, error) {
+	v, err := NewVolume(dir, dirIdx, collection, needle.VolumeId(id), needleMapKind, nil, nil, 0, 0, ldbTimeout)
+	if err != nil {
+		return nil, err
+	}
+	// load without starting the worker
+	if err := v.load(true, false, needleMapKind, 0); err != nil {
+		v.Close()
+		return nil, err
+	}
+	return v, nil
+}
+
+func mustReload(t *testing.T, dir string) *Volume {
+	t.Helper()
+	v, err := loadVolumeWithoutWorker(dir, dir, "", 1, NeedleMapInMemory, 0)
+	if err != nil {
+		t.Fatalf("reload volume: %v", err)
+	}
+	return v
+}
+
+func mustRead(t *testing.T, v *Volume, id uint64) []byte {
+	t.Helper()
+	n := newEmptyNeedle(id)
+	if _, err := v.readNeedle(n, nil, nil); err != nil {
+		t.Fatalf("read needle %d: %v", id, err)
+	}
+	return n.Data
+}
+
+func fileSize(t *testing.T, path string) int64 {
+	t.Helper()
+	st, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat %s: %v", path, err)
+	}
+	return st.Size()
+}
+
+type idxEntry struct {
+	key    types.NeedleId
+	offset types.Offset
+	size   types.Size
+}
+
+func readAllIdxEntries(t *testing.T, idxPath string) []idxEntry {
+	t.Helper()
+	f, err := os.Open(idxPath)
+	if err != nil {
+		t.Fatalf("open %s: %v", idxPath, err)
+	}
+	defer f.Close()
+	var entries []idxEntry
+	offset := int64(0)
+	for {
+		row := make([]byte, types.NeedleMapEntrySize)
+		n, err := f.ReadAt(row, offset)
+		if err != nil {
+			break
+		}
+		if n < types.NeedleMapEntrySize {
+			break
+		}
+		key := types.BytesToNeedleId(row[:8])
+		off := types.BytesToOffset(row[8:12])
+		sz := types.BytesToSize(row[12:16])
+		entries = append(entries, idxEntry{key: key, offset: off, size: sz})
+		offset += types.NeedleMapEntrySize
+	}
+	return entries
+}
+
+// TestRepairIdxHeadTombstones_RestoresClobberedRows checks that a volume whose
+// .idx head was overwritten with offset-0 tombstones serves its first needles
+// again after a reload, without a full weed fix rebuild.
+func TestRepairIdxHeadTombstones_RestoresClobberedRows(t *testing.T) {
+	dir := t.TempDir()
+	const needleCount = 12
+	const clobbered = 4
+
+	written := writeTestVolume(t, dir, needleCount)
+	idxPath := filepath.Join(dir, "1.idx")
+	sizeBefore := fileSize(t, idxPath)
+
+	// The rewrite replaces .idx wholesale, so it must not widen the mode.
+	if err := os.Chmod(idxPath, 0600); err != nil {
+		t.Fatalf("chmod idx: %v", err)
+	}
+
+	// Deletes against needles 9..12 land on the front of .idx and take the
+	// rows indexing needles 1..4 with them.
+	clobberIdxHead(t, idxPath, []uint64{9, 10, 11, 12})
+
+	v := mustReload(t, dir)
+	defer v.Close()
+
+	for i := uint64(1); i <= needleCount; i++ {
+		if i >= 9 {
+			// genuinely deleted by the tombstones that did the damage
+			continue
+		}
+		if got, want := mustRead(t, v, i), written[i].Data; string(got) != string(want) {
+			t.Fatalf("needle %d: data mismatch after recovery", i)
+		}
+	}
+
+	if got, want := fileSize(t, idxPath), sizeBefore+int64(clobbered*types.NeedleMapEntrySize); got != want {
+		t.Fatalf("idx size after recovery: got %d, want %d", got, want)
+	}
+
+	if st, err := os.Stat(idxPath); err != nil {
+		t.Fatalf("stat idx: %v", err)
+	} else if got := st.Mode().Perm(); got != 0600 {
+		t.Fatalf("idx mode after recovery: got %o, want 600", got)
+	}
+
+	// The recovered rows go back in front, so .idx is in .dat append order
+	// again: the fingerprint is gone and the last row is still the .dat tail.
+	entries := readAllIdxEntries(t, idxPath)
+	if entries[0].offset.ToActualOffset() != int64(v.SuperBlock.BlockSize()) {
+		t.Fatalf("first row does not index the first needle in .dat: %+v", entries[0])
+	}
+	for i := 1; i < clobbered; i++ {
+		if entries[i-1].offset.ToActualOffset() >= entries[i].offset.ToActualOffset() {
+			t.Fatalf("recovered rows are not in .dat order: %+v then %+v", entries[i-1], entries[i])
+		}
+	}
+
+	// The recovery is idempotent: a second load finds nothing left to restore.
+	v.Close()
+	v = mustReload(t, dir)
+	if got, want := fileSize(t, idxPath), sizeBefore+int64(clobbered*types.NeedleMapEntrySize); got != want {
+		t.Fatalf("idx grew on second load: got %d, want %d", got, want)
+	}
+}
+
+// TestRepairIdxHeadTombstones_ReadOnlyVolume covers the shape the damage
+// actually occurs in: a read-only volume, whose reads go through the sorted
+// needle map. The recovery has to land before .sdx is regenerated, or the
+// restored rows never reach the map that answers the read.
+func TestRepairIdxHeadTombstones_ReadOnlyVolume(t *testing.T) {
+	dir := t.TempDir()
+	written := writeTestVolume(t, dir, 8)
+	clobberIdxHead(t, filepath.Join(dir, "1.idx"), []uint64{7, 8})
+
+	if err := volume_info.SaveVolumeInfo(filepath.Join(dir, "1.vif"), &volume_server_pb.VolumeInfo{
+		Version:  uint32(needle.CurrentVersion),
+		ReadOnly: true,
+	}); err != nil {
+		t.Fatalf("save vif: %v", err)
+	}
+
+	v := mustReload(t, dir)
+	defer v.Close()
+
+	if _, isSorted := v.nm.(*SortedFileNeedleMap); !isSorted {
+		t.Fatalf("expected a sorted needle map, got %T", v.nm)
+	}
+	for i := uint64(1); i <= 2; i++ {
+		if got, want := mustRead(t, v, i), written[i].Data; string(got) != string(want) {
+			t.Fatalf("needle %d: data mismatch after recovery", i)
+		}
+	}
+}
+
+// TestRepairIdxHeadTombstones_LeavesHealthyIdxAlone guards the fingerprint: a
+// volume with ordinary deletes must not be rewritten.
+func TestRepairIdxHeadTombstones_LeavesHealthyIdxAlone(t *testing.T) {
+	dir := t.TempDir()
+	writeTestVolume(t, dir, 6)
+	idxPath := filepath.Join(dir, "1.idx")
+
+	v := mustReload(t, dir)
+	if _, err := v.doDeleteRequest(newEmptyNeedle(3)); err != nil {
+		t.Fatalf("delete needle 3: %v", err)
+	}
+	v.Close()
+
+	sizeBefore := fileSize(t, idxPath)
+	entriesBefore := readAllIdxEntries(t, idxPath)
+
+	v = mustReload(t, dir)
+	defer v.Close()
+
+	if got := fileSize(t, idxPath); got != sizeBefore {
+		t.Fatalf("healthy idx was rewritten: got %d, want %d", got, sizeBefore)
+	}
+	if got := readAllIdxEntries(t, idxPath); len(got) != len(entriesBefore) {
+		t.Fatalf("healthy idx row count changed: got %d, want %d", len(got), len(entriesBefore))
+	}
+	if _, err := v.readNeedle(newEmptyNeedle(3), nil, nil); err != ErrorDeleted {
+		t.Fatalf("needle 3 should stay deleted, got %v", err)
+	}
+}
+
+// TestRepairIdxHeadTombstones_KeepsDeletedNeedlesDeleted checks that a needle
+// deleted before the damage is not resurrected: its tombstone row survives at
+// the tail of .idx, so the key is still indexed and stays out of the recovery.
+// It stays unreadable either way -- as deleted if its Put row survived, as
+// not-found if the tombstone is all the .idx has left of it.
+func TestRepairIdxHeadTombstones_KeepsDeletedNeedlesDeleted(t *testing.T) {
+	dir := t.TempDir()
+	writeTestVolume(t, dir, 8)
+	idxPath := filepath.Join(dir, "1.idx")
+
+	v := mustReload(t, dir)
+	if _, err := v.doDeleteRequest(newEmptyNeedle(2)); err != nil {
+		t.Fatalf("delete needle 2: %v", err)
+	}
+	v.Close()
+
+	clobberIdxHead(t, idxPath, []uint64{7, 8})
+
+	v = mustReload(t, dir)
+	defer v.Close()
+
+	if _, err := v.readNeedle(newEmptyNeedle(2), nil, nil); err != ErrorDeleted && err != ErrorNotFound {
+		t.Fatalf("needle 2 was resurrected, got %v", err)
+	}
+	if _, err := v.readNeedle(newEmptyNeedle(1), nil, nil); err != nil {
+		t.Fatalf("needle 1 should have been recovered: %v", err)
+	}
+}

--- a/weed/storage/volume_loading.go
+++ b/weed/storage/volume_loading.go
@@ -119,10 +119,13 @@ func (v *Volume) load(alsoLoadIndex bool, createDatIfMissing bool, needleMapKind
 		// Recover rows that deletes on a tiered read-only volume overwrote at
 		// the front of .idx. Best effort: a volume that cannot be repaired is
 		// still servable for everything the surviving rows index.
-		if restored, repairErr := v.repairIdxHeadTombstones(); repairErr != nil {
-			glog.Warningf("volume %d: recover overwritten %s rows: %v", v.Id, v.FileName(".idx"), repairErr)
-		} else if restored > 0 {
-			glog.V(0).Infof("volume %d: recovered %d overwritten %s rows from %s", v.Id, restored, v.FileName(".idx"), v.FileName(".dat"))
+		if !v.HasRemoteFile() {
+			restored, repairErr := v.repairIdxHeadTombstones()
+			if repairErr != nil {
+				glog.Warningf("volume %d: recover overwritten %s rows: %v", v.Id, v.FileName(".idx"), repairErr)
+			} else if restored > 0 {
+				glog.V(0).Infof("volume %d: recovered %d overwritten %s rows from %s", v.Id, restored, v.FileName(".idx"), v.FileName(".dat"))
+			}
 		}
 		var indexFile *os.File
 		if v.noWriteOrDelete {

--- a/weed/storage/volume_loading.go
+++ b/weed/storage/volume_loading.go
@@ -116,6 +116,14 @@ func (v *Volume) load(alsoLoadIndex bool, createDatIfMissing bool, needleMapKind
 		if err := v.checkIdxFile(); err != nil {
 			glog.Fatalf("check volume idx file %s: %v", v.FileName(".idx"), err)
 		}
+		// Recover rows that deletes on a tiered read-only volume overwrote at
+		// the front of .idx. Best effort: a volume that cannot be repaired is
+		// still servable for everything the surviving rows index.
+		if restored, repairErr := v.repairIdxHeadTombstones(); repairErr != nil {
+			glog.Warningf("volume %d: recover overwritten %s rows: %v", v.Id, v.FileName(".idx"), repairErr)
+		} else if restored > 0 {
+			glog.V(0).Infof("volume %d: recovered %d overwritten %s rows from %s", v.Id, restored, v.FileName(".idx"), v.FileName(".dat"))
+		}
 		var indexFile *os.File
 		if v.noWriteOrDelete {
 			glog.V(0).Infoln("open to read file", v.FileName(".idx"))


### PR DESCRIPTION
When a delete hits a read-only volume backed by a remote tier, the sorted-file needle map opened .idx read-write but never seeded its write position, so every delete overwrote one more row at the front with an offset-0 tombstone instead of appending. The Put rows indexing the first needles in .dat were lost; those needles 404 even though .dat still holds them.

The damage has a fingerprint: .idx opens with a run of offset-0 tombstones, which a healthy .idx never does. Detect it at load time, re-derive the clobbered rows from a header-only scan of .dat (cheap even against a remote tier), and rewrite .idx with the recovered rows in front and the surviving tail appended after. The fingerprint disappears so later loads stop after one row, and .idx is back in .dat append order.

Adapt for 3.77-udm:
- drop needle.IsSupportedVersion (absent in 3.77)
- size.IsTombstone -> size.IsDeleted
- drop util.FsyncDir (absent in 3.77)

# What problem are we solving?

https://github.com/seaweedfs/seaweedfs/issues/10466

# How are we solving the problem?


# How is the PR tested?



# Checks
- [ ] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.
- [ ] All AI code review comments have been addressed. No more comments to fix if reviewed again. Reviewer may request additional gemini and copilot reviews.

# Checks for AI generated PRs
- [ ] I have reviewed every line of code.
- [ ] The PR is kept as minimum as possible. Large PRs would not be accepted.
